### PR TITLE
Clean up scale slider UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,14 +88,6 @@
             transition: transform 0.3s ease;
         }
 
-        /* Margin system */
-        .zine.margin-adjusted {
-            transition: padding 0.3s ease;
-        }
-
-        .zine > *.margin-adjusted {
-            transition: margin 0.3s ease;
-        }
 
         /* Slider styling */
         .slider {
@@ -149,12 +141,6 @@
             transform: scale(1.1);
         }
 
-        /* Preset button active state */
-        .scale-preset.active,
-        .margin-preset.active {
-            background: #3b82f6 !important;
-            color: white !important;
-        }
 
         .page-number {
             position: absolute;
@@ -275,14 +261,6 @@
                 transform-origin: center !important;
             }
 
-            /* Preserve margin adjustments in print mode */
-            .zine.margin-adjusted {
-                padding: inherit !important;
-            }
-
-            .zine > *.margin-adjusted {
-                margin: inherit !important;
-            }
 
             .page-number {
                 display: none;
@@ -316,68 +294,20 @@
 
 
         <!-- Scaling Controls -->
-        <div class="no-print bg-white p-6 rounded-lg shadow-md max-w-4xl mx-auto mb-8">
-            <h3 class="text-lg font-semibold text-gray-800 mb-4 text-center">Page Scaling & Layout Controls</h3>
+        <div class="no-print bg-white p-6 rounded-lg shadow-md max-w-lg mx-auto mb-8">
+            <h3 class="text-lg font-semibold text-gray-800 mb-4 text-center">Page Scale</h3>
             
-            <!-- Scale Controls -->
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-                <div>
-                    <label for="scale-slider" class="block text-sm font-medium text-gray-700 mb-2">
-                        Page Scale: <span id="scale-value">100%</span>
-                    </label>
-                    <input type="range" id="scale-slider" min="50" max="200" value="100" 
-                           class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer slider">
-                    <div class="flex justify-between text-xs text-gray-500 mt-1">
-                        <span>50%</span>
-                        <span>100%</span>
-                        <span>200%</span>
-                    </div>
+            <div>
+                <label for="scale-slider" class="block text-sm font-medium text-gray-700 mb-2">
+                    Scale: <span id="scale-value">100%</span>
+                </label>
+                <input type="range" id="scale-slider" min="50" max="200" value="100" 
+                       class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer slider">
+                <div class="flex justify-between text-xs text-gray-500 mt-1">
+                    <span>50%</span>
+                    <span>100%</span>
+                    <span>200%</span>
                 </div>
-                
-                <div>
-                    <label for="margin-slider" class="block text-sm font-medium text-gray-700 mb-2">
-                        Page Margins: <span id="margin-value">Normal</span>
-                    </label>
-                    <input type="range" id="margin-slider" min="0" max="100" value="50" 
-                           class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer slider">
-                    <div class="flex justify-between text-xs text-gray-500 mt-1">
-                        <span>No Margins</span>
-                        <span>Normal</span>
-                        <span>Large</span>
-                    </div>
-                </div>
-            </div>
-            
-            <!-- Quick Scale Presets -->
-            <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2">Quick Scale Presets:</label>
-                <div class="flex flex-wrap gap-2 justify-center">
-                    <button class="scale-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-scale="75">75%</button>
-                    <button class="scale-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-scale="100">100%</button>
-                    <button class="scale-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-scale="125">125%</button>
-                    <button class="scale-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-scale="150">150%</button>
-                    <button class="scale-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-scale="175">175%</button>
-                    <button class="scale-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-scale="200">200%</button>
-                </div>
-            </div>
-            
-            <!-- Margin Presets -->
-            <div class="mb-4">
-                <label class="block text-sm font-medium text-gray-700 mb-2">Margin Presets:</label>
-                <div class="flex flex-wrap gap-2 justify-center">
-                    <button class="margin-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-margin="0">No Margins</button>
-                    <button class="margin-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-margin="25">Small</button>
-                    <button class="margin-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-margin="50">Normal</button>
-                    <button class="margin-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-margin="75">Large</button>
-                    <button class="margin-preset px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-md text-sm transition" data-margin="100">Extra Large</button>
-                </div>
-            </div>
-            
-            <!-- Reset Button -->
-            <div class="text-center">
-                <button id="reset-scaling" class="px-4 py-2 bg-gray-500 hover:bg-gray-600 text-white rounded-md text-sm transition">
-                    Reset to Default
-                </button>
             </div>
         </div>
 
@@ -415,15 +345,9 @@
             // Scaling controls
             const scaleSlider = document.getElementById('scale-slider');
             const scaleValue = document.getElementById('scale-value');
-            const marginSlider = document.getElementById('margin-slider');
-            const marginValue = document.getElementById('margin-value');
-            const scalePresets = document.querySelectorAll('.scale-preset');
-            const marginPresets = document.querySelectorAll('.margin-preset');
-            const resetScaling = document.getElementById('reset-scaling');
             
             // Current scaling state
             let currentScale = 100;
-            let currentMargin = 50;
             
             // Scaling functions
             function updateScale(scale) {
@@ -449,49 +373,6 @@
                     img.style.transform = `scale(${scale / 100})`;
                 });
                 
-                // Update active preset
-                scalePresets.forEach(preset => {
-                    preset.classList.remove('active');
-                    if (parseInt(preset.dataset.scale) === scale) {
-                        preset.classList.add('active');
-                    }
-                });
-            }
-            
-            function updateMargin(margin) {
-                currentMargin = margin;
-                const marginText = margin === 0 ? 'No Margins' : 
-                                 margin === 25 ? 'Small' :
-                                 margin === 50 ? 'Normal' :
-                                 margin === 75 ? 'Large' : 'Extra Large';
-                marginValue.textContent = marginText;
-                marginSlider.value = margin;
-                
-                // Update zine container padding
-                zine.classList.add('margin-adjusted');
-                const paddingValue = (margin / 100) * 2; // Convert to rem
-                zine.style.padding = `${paddingValue}rem`;
-                
-                // Update individual page margins
-                const pages = document.querySelectorAll('.zine > *');
-                pages.forEach(page => {
-                    page.classList.add('margin-adjusted');
-                    const marginValue = (margin / 100) * 0.5; // Convert to rem
-                    page.style.margin = `${marginValue}rem`;
-                });
-                
-                // Update active preset
-                marginPresets.forEach(preset => {
-                    preset.classList.remove('active');
-                    if (parseInt(preset.dataset.margin) === margin) {
-                        preset.classList.add('active');
-                    }
-                });
-            }
-            
-            function resetToDefault() {
-                updateScale(100);
-                updateMargin(50);
             }
 
             // Generate the 8 blank page placeholders
@@ -633,32 +514,8 @@
                 updateScale(parseInt(e.target.value));
             });
             
-            marginSlider.addEventListener('input', (e) => {
-                updateMargin(parseInt(e.target.value));
-            });
-            
-            // Scale preset buttons
-            scalePresets.forEach(preset => {
-                preset.addEventListener('click', () => {
-                    updateScale(parseInt(preset.dataset.scale));
-                });
-            });
-            
-            // Margin preset buttons
-            marginPresets.forEach(preset => {
-                preset.addEventListener('click', () => {
-                    updateMargin(parseInt(preset.dataset.margin));
-                });
-            });
-            
-            // Reset button
-            resetScaling.addEventListener('click', () => {
-                resetToDefault();
-            });
-            
             // Initialize with default values
             updateScale(100);
-            updateMargin(50);
 
         });
     </script>


### PR DESCRIPTION
### **User description**
Remove margin controls and quick select buttons to simplify the interface and focus solely on page scaling.

---
<a href="https://cursor.com/background-agent?bcId=bc-f86ab5da-6e3d-4f2e-8292-dac45254ed6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f86ab5da-6e3d-4f2e-8292-dac45254ed6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


___

### **PR Type**
Enhancement


___

### **Description**
- Remove margin controls and related CSS styles

- Remove quick select preset buttons for scaling

- Simplify UI to focus solely on page scaling

- Reduce control panel width and complexity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Complex UI with margin & scale controls"] --> B["Simplified UI with scale only"]
  C["Margin sliders & presets"] --> D["Removed"]
  E["Scale presets buttons"] --> D
  F["Reset button"] --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Simplify UI by removing margin controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Remove margin control sliders and related CSS styles<br> <li> Remove quick select preset buttons for both scale and margin<br> <li> Remove reset button and associated JavaScript functions<br> <li> Simplify control panel layout and reduce container width</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/8-page-mini-zine-maker/pull/2/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+12/-155</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

Simplify the page scaling interface by removing margin controls, quick presets, and related CSS/JS, leaving only a single scale slider.

Enhancements:
- Remove margin slider, margin presets, and quick scale preset buttons from the UI markup
- Eliminate CSS rules for margin adjustments and active preset states
- Strip out JavaScript logic for margin handling, preset toggling, and reset functionality
- Adjust control container width and heading to reflect the simplified scale-only interface