### PR TITLE
Investigate fill command printer issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -593,6 +593,9 @@
                     tempContainer.appendChild(zineClone);
                     document.body.appendChild(tempContainer);
                     
+                    // Disable html2canvas logging to prevent error text overlay
+                    window.html2canvas.logging = false;
+                    
                     // Capture the zine as canvas
                     const canvas = await html2canvas(zineClone, {
                         scale: 2,

--- a/zine.html
+++ b/zine.html
@@ -607,6 +607,9 @@
                     tempContainer.appendChild(zineClone);
                     document.body.appendChild(tempContainer);
                     
+                    // Disable html2canvas logging to prevent error text overlay
+                    window.html2canvas.logging = false;
+                    
                     // Capture the zine as canvas
                     const canvas = await html2canvas(zineClone, {
                         scale: 2,


### PR DESCRIPTION
### **User description**
Add `logging: false` to html2canvas configuration to prevent error text from overlaying on printed zines.

---
<a href="https://cursor.com/background-agent?bcId=bc-78948078-11b4-4ee5-8729-a5bfae61d33e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78948078-11b4-4ee5-8729-a5bfae61d33e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Bug Fixes:
- Disable html2canvas logging to prevent error text overlay on printed zines


___

### **PR Type**
Bug fix


___

### **Description**
- Disable html2canvas logging to prevent error text overlay

- Fix printer issues when generating zine PDFs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["html2canvas rendering"] -- "disable logging" --> B["Clean PDF output"]
  B --> C["No error text overlay"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Disable html2canvas logging for clean rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Add <code>window.html2canvas.logging = false</code> before canvas capture<br> <li> Include explanatory comment about preventing error text overlay</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/8-page-mini-zine-maker/pull/6/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zine.html</strong><dd><code>Disable html2canvas logging for clean rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

zine.html

<ul><li>Add <code>window.html2canvas.logging = false</code> before canvas capture<br> <li> Include explanatory comment about preventing error text overlay</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/8-page-mini-zine-maker/pull/6/files#diff-06e36c83cfd33d33c429bb87c2bbc8185fcda1d4c925b81e6735c14270e6717b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

