### PR TITLE
Fetch and place image on page two

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,20 +294,17 @@
             <p id="upload-status" class="text-center text-sm text-gray-500 mt-3"></p>
         </div>
 
-        <!-- PNG Upload Section for Page 2 -->
+        <!-- Reference Layout Info -->
         <div class="no-print bg-white p-6 rounded-lg shadow-md max-w-lg mx-auto mb-8">
-            <h3 class="text-lg font-semibold text-gray-800 mb-4 text-center">Page 2 Image (Back Cover)</h3>
-            <label for="png-upload" class="w-full text-center cursor-pointer bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-6 rounded-md shadow-lg transition transform hover:scale-105 flex items-center justify-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-                    <circle cx="8.5" cy="8.5" r="1.5"></circle>
-                    <polyline points="21 15 16 10 5 21"></polyline>
-                </svg>
-                <span id="png-upload-text">Upload PNG for Page 2</span>
-            </label>
-            <input type="file" id="png-upload" class="hidden" accept="image/png">
-            <p id="png-upload-status" class="text-center text-sm text-gray-500 mt-3"></p>
+            <h3 class="text-lg font-semibold text-gray-800 mb-4 text-center">Zine Layout Reference</h3>
+            <p class="text-sm text-gray-600 text-center mb-4">Using the standard 8-page zine layout with reference image on page 2</p>
+            <div class="text-center">
+                <button id="load-reference-btn" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-md transition transform hover:scale-105">
+                    Load Reference Layout
+                </button>
+            </div>
         </div>
+
 
 
         <!-- Scaling Controls -->
@@ -368,10 +365,9 @@
             const uploadText = document.getElementById('upload-text');
             const uploadStatus = document.getElementById('upload-status');
             
-            // PNG upload elements
-            const pngUpload = document.getElementById('png-upload');
-            const pngUploadText = document.getElementById('png-upload-text');
-            const pngUploadStatus = document.getElementById('png-upload-status');
+            // Reference layout elements
+            const loadReferenceBtn = document.getElementById('load-reference-btn');
+            
             
             // Scaling controls
             const scaleSlider = document.getElementById('scale-slider');
@@ -439,42 +435,25 @@
                 zine.appendChild(page);
             }
 
-            // PNG upload handler for page 2
-            pngUpload.addEventListener('change', (event) => {
-                const file = event.target.files[0];
-                if (!file || !file.type.startsWith('image/')) {
-                    pngUploadStatus.textContent = 'Please select a PNG image file.';
-                    pngUploadStatus.classList.add('text-red-500', 'font-bold');
-                    return;
-                }
-
-                pngUploadText.textContent = 'Processing...';
-                pngUploadStatus.classList.remove('text-red-500', 'font-bold');
-                pngUploadStatus.textContent = `Processing "${file.name}"...`;
-
-                const fileReader = new FileReader();
-                fileReader.onload = function() {
-                    // Always place PNG on page 2
-                    const imgPreview = document.getElementById('preview-2');
-                    imgPreview.src = this.result;
-                    
-                    // Hide placeholder for page 2
-                    const placeholder = document.querySelector('#content-2 .placeholder');
-                    placeholder.style.display = 'none';
-                    
-                    pngUploadText.textContent = 'Upload New PNG';
-                    pngUploadStatus.textContent = `Successfully loaded image for page 2!`;
-                    pngUploadStatus.classList.add('text-green-600', 'font-bold');
-                };
+            // Load reference layout image on page 2
+            loadReferenceBtn.addEventListener('click', () => {
+                const referenceImageUrl = 'https://tahoetrailguide.com/wp-content/uploads/2018/05/8-Page_Zine_Page_Layout_1_Page_Numbers_Jared_Manninen_300ppi-1024x791.jpg';
                 
-                fileReader.onerror = function() {
-                    pngUploadStatus.classList.add('text-red-500', 'font-bold');
-                    pngUploadStatus.textContent = 'Error: Could not read the image file.';
-                    pngUploadText.textContent = 'Try a Different PNG';
-                };
+                // Load the reference image on page 2
+                const imgPreview = document.getElementById('preview-2');
+                imgPreview.src = referenceImageUrl;
                 
-                fileReader.readAsDataURL(file);
+                // Hide placeholder for page 2
+                const placeholder = document.querySelector('#content-2 .placeholder');
+                placeholder.style.display = 'none';
+                
+                // Update button text
+                loadReferenceBtn.textContent = 'Reference Loaded ✓';
+                loadReferenceBtn.classList.remove('bg-green-600', 'hover:bg-green-700');
+                loadReferenceBtn.classList.add('bg-gray-500', 'cursor-not-allowed');
+                loadReferenceBtn.disabled = true;
             });
+
 
             // PDF upload handler with improved image conversion
             pdfUpload.addEventListener('change', async (event) => {

--- a/zine.html
+++ b/zine.html
@@ -278,20 +278,17 @@
             <p id="upload-status" class="text-center text-sm text-gray-500 mt-3"></p>
         </div>
 
-        <!-- PNG Upload Section for Page 2 -->
+        <!-- Reference Layout Info -->
         <div class="no-print bg-white p-6 rounded-lg shadow-md max-w-lg mx-auto mb-8">
-            <h3 class="text-lg font-semibold text-gray-800 mb-4 text-center">Page 2 Image (Back Cover)</h3>
-            <label for="png-upload" class="w-full text-center cursor-pointer bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-6 rounded-md shadow-lg transition transform hover:scale-105 flex items-center justify-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-                    <circle cx="8.5" cy="8.5" r="1.5"></circle>
-                    <polyline points="21 15 16 10 5 21"></polyline>
-                </svg>
-                <span id="png-upload-text">Upload PNG for Page 2</span>
-            </label>
-            <input type="file" id="png-upload" class="hidden" accept="image/png">
-            <p id="png-upload-status" class="text-center text-sm text-gray-500 mt-3"></p>
+            <h3 class="text-lg font-semibold text-gray-800 mb-4 text-center">Zine Layout Reference</h3>
+            <p class="text-sm text-gray-600 text-center mb-4">Using the standard 8-page zine layout with reference image on page 2</p>
+            <div class="text-center">
+                <button id="load-reference-btn" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-md transition transform hover:scale-105">
+                    Load Reference Layout
+                </button>
+            </div>
         </div>
+
 
 
         <!-- Scaling Controls -->
@@ -352,10 +349,9 @@
             const uploadText = document.getElementById('upload-text');
             const uploadStatus = document.getElementById('upload-status');
             
-            // PNG upload elements
-            const pngUpload = document.getElementById('png-upload');
-            const pngUploadText = document.getElementById('png-upload-text');
-            const pngUploadStatus = document.getElementById('png-upload-status');
+            // Reference layout elements
+            const loadReferenceBtn = document.getElementById('load-reference-btn');
+            
             
             // Scaling controls
             const scaleSlider = document.getElementById('scale-slider');
@@ -422,42 +418,25 @@
                 zine.appendChild(page);
             }
 
-            // PNG upload handler for page 2
-            pngUpload.addEventListener('change', (event) => {
-                const file = event.target.files[0];
-                if (!file || !file.type.startsWith('image/')) {
-                    pngUploadStatus.textContent = 'Please select a PNG image file.';
-                    pngUploadStatus.classList.add('text-red-500', 'font-bold');
-                    return;
-                }
-
-                pngUploadText.textContent = 'Processing...';
-                pngUploadStatus.classList.remove('text-red-500', 'font-bold');
-                pngUploadStatus.textContent = `Processing "${file.name}"...`;
-
-                const fileReader = new FileReader();
-                fileReader.onload = function() {
-                    // Always place PNG on page 2
-                    const imgPreview = document.getElementById('preview-2');
-                    imgPreview.src = this.result;
-                    
-                    // Hide placeholder for page 2
-                    const placeholder = document.querySelector('#content-2 .placeholder');
-                    placeholder.style.display = 'none';
-                    
-                    pngUploadText.textContent = 'Upload New PNG';
-                    pngUploadStatus.textContent = `Successfully loaded image for page 2!`;
-                    pngUploadStatus.classList.add('text-green-600', 'font-bold');
-                };
+            // Load reference layout image on page 2
+            loadReferenceBtn.addEventListener('click', () => {
+                const referenceImageUrl = 'https://tahoetrailguide.com/wp-content/uploads/2018/05/8-Page_Zine_Page_Layout_1_Page_Numbers_Jared_Manninen_300ppi-1024x791.jpg';
                 
-                fileReader.onerror = function() {
-                    pngUploadStatus.classList.add('text-red-500', 'font-bold');
-                    pngUploadStatus.textContent = 'Error: Could not read the image file.';
-                    pngUploadText.textContent = 'Try a Different PNG';
-                };
+                // Load the reference image on page 2
+                const imgPreview = document.getElementById('preview-2');
+                imgPreview.src = referenceImageUrl;
                 
-                fileReader.readAsDataURL(file);
+                // Hide placeholder for page 2
+                const placeholder = document.querySelector('#content-2 .placeholder');
+                placeholder.style.display = 'none';
+                
+                // Update button text
+                loadReferenceBtn.textContent = 'Reference Loaded ✓';
+                loadReferenceBtn.classList.remove('bg-green-600', 'hover:bg-green-700');
+                loadReferenceBtn.classList.add('bg-gray-500', 'cursor-not-allowed');
+                loadReferenceBtn.disabled = true;
             });
+
 
             // PDF upload handler with improved image conversion and error handling
             pdfUpload.addEventListener('change', async (event) => {


### PR DESCRIPTION
### **User description**
Add a dedicated PNG upload feature to place an image on page 2 of the zine layout, ensuring it always serves as the back cover.

The user requested to have a specific image always appear on page 2 of the printable zine, independent of the uploaded PDF content. This feature provides a separate upload mechanism for a PNG image that will be rendered in the page 2 position.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f0cd17b-d477-435b-8326-5ac179eef2e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f0cd17b-d477-435b-8326-5ac179eef2e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Add a dedicated reference-layout feature to place a static PNG image on page 2 of the zine, ensuring it always appears as the back cover.

New Features:
- Introduce a "Zine Layout Reference" panel with a "Load Reference Layout" button in both index.html and zine.html screens
- Implement a click handler that loads a predefined PNG into the page 2 preview, hides its placeholder, and disables the button after use


___

### **PR Type**
Enhancement


___

### **Description**
- Add reference layout button for zine page 2

- Load external reference image on page 2

- Hide placeholder when reference image loaded

- Update button state after loading reference


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User clicks Load Reference"] --> B["Fetch reference image"]
  B --> C["Display on page 2"]
  C --> D["Hide placeholder"]
  D --> E["Update button state"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add reference layout loader functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Add reference layout UI section with button<br> <li> Implement click handler to load external image on page 2<br> <li> Hide placeholder and update button state after loading</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/8-page-mini-zine-maker/pull/7/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zine.html</strong><dd><code>Add reference layout loader functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

zine.html

<ul><li>Add reference layout UI section with button<br> <li> Implement click handler to load external image on page 2<br> <li> Hide placeholder and update button state after loading</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/8-page-mini-zine-maker/pull/7/files#diff-06e36c83cfd33d33c429bb87c2bbc8185fcda1d4c925b81e6735c14270e6717b">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

