### PR TITLE
Debug print page count error

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,11 +582,24 @@
                                 margin: 0;
                             }
                             
+                            body {
+                                margin: 0;
+                                padding: 0;
+                                width: 100%;
+                                height: 100vh;
+                                overflow: hidden;
+                            }
+                            
                             .print-page {
-                                width: 100vw;
+                                width: 100%;
                                 height: 100vh;
                                 page-break-after: always;
                                 position: relative;
+                                display: block;
+                            }
+                            
+                            .print-page:last-child {
+                                page-break-after: auto;
                             }
                             
                             .front-side {
@@ -607,6 +620,20 @@
                                 background-repeat: no-repeat;
                                 background-position: center;
                                 transform: rotate(180deg);
+                                width: 100%;
+                                height: 100%;
+                            }
+                            
+                            .zine {
+                                display: grid;
+                                grid-template-areas:
+                                    "page8 page1 page2 page7"
+                                    "page6 page3 page4 page5";
+                                width: 100%;
+                                height: 100%;
+                                gap: 0;
+                                padding: 0;
+                                margin: 0;
                             }
                             
                             .zine > * {

--- a/zine.html
+++ b/zine.html
@@ -688,11 +688,24 @@
                                 margin: 0;
                             }
                             
+                            body {
+                                margin: 0;
+                                padding: 0;
+                                width: 100%;
+                                height: 100vh;
+                                overflow: hidden;
+                            }
+                            
                             .print-page {
-                                width: 100vw;
+                                width: 100%;
                                 height: 100vh;
                                 page-break-after: always;
                                 position: relative;
+                                display: block;
+                            }
+                            
+                            .print-page:last-child {
+                                page-break-after: auto;
                             }
                             
                             .front-side {
@@ -713,6 +726,20 @@
                                 background-repeat: no-repeat;
                                 background-position: center;
                                 transform: rotate(180deg);
+                                width: 100%;
+                                height: 100%;
+                            }
+                            
+                            .zine {
+                                display: grid;
+                                grid-template-areas:
+                                    "page8 page1 page2 page7"
+                                    "page6 page3 page4 page5";
+                                width: 100%;
+                                height: 100%;
+                                gap: 0;
+                                padding: 0;
+                                margin: 0;
                             }
                             
                             .zine > * {


### PR DESCRIPTION
### **User description**
Fix print layout CSS to correctly display 2 pages instead of 823.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fea2a1a-4d7e-4b58-9aee-ee30981b22bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5fea2a1a-4d7e-4b58-9aee-ee30981b22bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Fix print layout CSS to correctly display the intended two pages by constraining dimensions and page breaks

Bug Fixes:
- Reset body margin, padding, width, height, and overflow to enforce full-viewport print sizing
- Change .print-page width from 100vw to 100% and add display:block plus last-child page-break rule
- Expand .front-side dimensions to fill container and define .zine as a grid with specific template areas to arrange pages correctly


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix print page count from 823 to 2 pages

- Improve print layout CSS for proper page dimensions

- Add grid layout for zine page arrangement

- Enhance page break behavior for last page


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Print Page Width"] -- "100vw → 100%" --> B["Correct Page Count"]
  C["Body Styles"] -- "Add margins/overflow" --> D["Full Page Display"]
  E["Zine Grid"] -- "Define template areas" --> F["Proper Page Layout"]
  B --> G["2 Pages Instead of 823"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Fix print CSS and add zine grid layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Change <code>.print-page</code> width from <code>100vw</code> to <code>100%</code><br> <li> Add body print styles with full viewport dimensions<br> <li> Add <code>.zine</code> grid layout with template areas<br> <li> Improve page break behavior for last page</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/8-page-mini-zine-maker/pull/10/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+28/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zine.html</strong><dd><code>Fix print CSS and add zine grid layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

zine.html

<ul><li>Change <code>.print-page</code> width from <code>100vw</code> to <code>100%</code><br> <li> Add body print styles with full viewport dimensions<br> <li> Add <code>.zine</code> grid layout with template areas<br> <li> Improve page break behavior for last page</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/8-page-mini-zine-maker/pull/10/files#diff-06e36c83cfd33d33c429bb87c2bbc8185fcda1d4c925b81e6735c14270e6717b">+28/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

