### PR TITLE
⚡ Bolt: Replace batched Promise.all with sliding window for PDF rendering

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - PDF Processing Rendering Optimization
+**Learning:** The previous implementation used discrete `Promise.all` batches for rendering PDF pages. In this pattern, the application would wait for the slowest page in a batch to render before moving to the next batch, leading to "stuttering" and under-utilization of resources.
+**Action:** Replace discrete `Promise.all` batch loops with a sliding window worker pool pattern using `Set` and `Promise.race`. This keeps exactly `N` (e.g., 4) concurrent workers active at any given time, smoothing out rendering performance and improving overall throughput.

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -261,13 +261,22 @@ class PDFZineMaker {
         this.ui.updateProgress(percent);
       };
 
-      for (let i = 1; i <= maxPages; i += batchSize) {
-        const batch = [];
-        for (let j = 0; j < batchSize && (i + j) <= maxPages; j++) {
-          batch.push(processPage(i + j));
+      // ⚡ Bolt: Replace discrete Promise.all batching with a sliding window worker pool.
+      // This keeps exactly `batchSize` workers active at all times, preventing "stuttering"
+      // where the pool waits for the slowest page in a batch before starting the next one.
+      const activeWorkers = new Set();
+
+      for (let i = 1; i <= maxPages; i++) {
+        const promise = processPage(i).finally(() => activeWorkers.delete(promise));
+        activeWorkers.add(promise);
+
+        if (activeWorkers.size >= batchSize) {
+          await Promise.race(activeWorkers);
         }
-        await Promise.all(batch);
       }
+
+      // Wait for remaining workers to finish
+      await Promise.all(activeWorkers);
 
       // Fill blanks
       for (let i = this.totalPages; i < rows * cols; i++) {


### PR DESCRIPTION
## **User description**
💡 What: Replaced discrete `Promise.all` batch loop in `processAdditionalPDF` with a sliding window worker pool pattern using `Set` and `Promise.race` with a concurrency limit of 4.
🎯 Why: The previous implementation used discrete `Promise.all` batches for rendering PDF pages. In this pattern, the application would wait for the slowest page in a batch to render before moving to the next batch, leading to "stuttering" and under-utilization of resources.
📊 Impact: Smooths out rendering performance and improves overall throughput by keeping exactly 4 concurrent workers active at any given time.
🔬 Measurement: Can be verified by observing the rendering progress bar. It should be smoother and complete faster, especially for documents where page rendering times vary significantly.

*PR created automatically by Jules for task [11531268407197153451](https://jules.google.com/task/11531268407197153451) started by @guitarbeat*

## Summary by Sourcery

Optimize PDF page processing concurrency to smooth rendering and improve throughput.

Enhancements:
- Replace batched Promise.all PDF page processing with a sliding window worker pool constrained by the existing batch size.
- Add a Jules bolt note documenting the PDF rendering optimization and the rationale for the new concurrency pattern.


___

## **CodeAnt-AI Description**
Smooth and faster PDF page processing with steady concurrency

### What Changed
- Page rendering now keeps a fixed number of concurrent page renders (sliding-window worker pool) instead of running in separate batches, so new pages start as soon as a worker frees up
- Progress updates advance more smoothly and overall processing finishes sooner for multi-page PDFs with uneven page render times
- Finalization behavior remains the same (blank pages filled, success status and toast shown)

### Impact
`✅ Smoother PDF rendering progress bar`
`✅ Faster completion for multi-page PDFs with variable page times`
`✅ Fewer rendering stalls on large or uneven documents`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
