### PR TITLE
⚡ Bolt: OffscreenCanvas for background PDF rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-02-18 - Repeated DOM Parsing Bottleneck in Grid Generation
 **Learning:** Repeatedly setting `.innerHTML` inside a loop (e.g., when generating custom grid layouts) causes significant performance overhead because the browser has to parse the HTML string and construct the DOM fragment on every iteration. This creates a noticeable bottleneck when generating larger grids (like 10x10).
 **Action:** Implement the Template/Flyweight pattern using a `<template>` element. Create the structure once in `template.innerHTML`, and inside the loop, use `element.replaceChildren(template.content.cloneNode(true))` to safely and quickly duplicate the DOM structure without repeated parsing.
+
+## 2025-02-18 - OffscreenCanvas for Background PDF Rendering
+**Learning:** Rendering PDF pages to a standard HTML `<canvas>` element (even if not attached to the DOM) can cause unnecessary DOM interactions and block the main thread, leading to UI jank during multi-page PDF processing.
+**Action:** Use `OffscreenCanvas` when supported. It avoids DOM overhead completely and allows background rendering and conversion to blobs using `convertToBlob`, significantly reducing main thread blocking.

--- a/src/js/pdf-processor.js
+++ b/src/js/pdf-processor.js
@@ -172,11 +172,16 @@ export class PDFProcessor {
       const width = Math.floor(viewport.width);
       const height = Math.floor(viewport.height);
 
-      // Create new canvas for each page to allow parallel processing
-      const canvas = document.createElement('canvas');
+      // ⚡ Bolt: Use OffscreenCanvas if supported to avoid DOM interactions and main thread blocking
+      const canvas = typeof OffscreenCanvas !== 'undefined'
+        ? new OffscreenCanvas(width, height)
+        : document.createElement('canvas');
       const context = canvas.getContext('2d', { alpha: false });
-      canvas.width = width;
-      canvas.height = height;
+
+      if (typeof OffscreenCanvas === 'undefined') {
+        canvas.width = width;
+        canvas.height = height;
+      }
 
       // Fill background white
       context.fillStyle = '#ffffff';
@@ -208,6 +213,12 @@ export class PDFProcessor {
    * @returns {Promise<string>} Blob URL
    */
   async canvasToBlob(canvas) {
+    // ⚡ Bolt: Fast path for OffscreenCanvas to prevent main thread blocking
+    if (typeof OffscreenCanvas !== 'undefined' && canvas instanceof OffscreenCanvas) {
+      const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.8 });
+      return URL.createObjectURL(blob);
+    }
+
     return new Promise((resolve) => {
       canvas.toBlob((blob) => {
         const url = URL.createObjectURL(blob);


### PR DESCRIPTION
💡 **What**: Added `OffscreenCanvas` support in `src/js/pdf-processor.js` for background rendering of PDF pages, with fallback to standard `canvas`.

🎯 **Why**: Rendering PDF pages to a standard HTML `<canvas>` element (even if not attached to the DOM via `document.createElement`) can cause unnecessary DOM interactions and block the main thread, leading to UI jank during multi-page PDF processing. `OffscreenCanvas` prevents these DOM bottlenecks.

📊 **Impact**: Reduces main thread blocking and memory overhead during PDF processing, particularly for large or complex PDFs where multiple pages are rendered concurrently. This should result in noticeably smoother UI animations and interactions while processing.

🔬 **Measurement**: Verify that uploading a large PDF processes without significant UI stuttering or freezes. Evaluated using Playwright test suite to ensure the functionality (specifically image blobs) remains perfectly intact and compatible across environments (including headless where OffscreenCanvas may/may not be available). All tests passed.

---
*PR created automatically by Jules for task [8570567232409893277](https://jules.google.com/task/8570567232409893277) started by @guitarbeat*

## Summary by Sourcery

Introduce OffscreenCanvas-based background PDF rendering with graceful fallback to standard canvas and document the performance learning in Bolt notes.

New Features:
- Add OffscreenCanvas support for rendering PDF pages when available, with fallback to HTML canvas.

Enhancements:
- Optimize canvas sizing and blob conversion paths to reduce main-thread blocking during PDF processing.

Documentation:
- Document OffscreenCanvas-based PDF rendering as a performance learning in the Bolt notes.