### PR TITLE
🛡️ Sentinel: [HIGH] Fix Client-Side DoS via Unbounded Cumulative PDF Pages

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -180,7 +180,13 @@ class PDFZineMaker {
         }
       }
 
-      this.totalPages = currentFilledPages + numPages;
+      const proposedTotalPages = currentFilledPages + numPages;
+      const ABSOLUTE_MAX_PAGES = 100;
+      if (proposedTotalPages > ABSOLUTE_MAX_PAGES) {
+        throw new Error(`Total pages exceed the absolute limit of ${ABSOLUTE_MAX_PAGES}. Cannot add this PDF.`);
+      }
+
+      this.totalPages = proposedTotalPages;
       this.selectedLayout = this.totalPages;
       const maxPages = numPages;
 
@@ -298,6 +304,13 @@ class PDFZineMaker {
       console.error('PDF Error:', error);
       this.ui.showProgress(false);
       toast.error('Error', error.message || 'Failed to process PDF.');
+
+      // Cleanup the failed file from the UI list
+      const fileIndex = this.uploadedFiles.findIndex(f => f.file === file);
+      if (fileIndex !== -1) {
+        this.uploadedFiles.splice(fileIndex, 1);
+        this.ui.updateUploadedFilesList(this.uploadedFiles);
+      }
     }
   }
 


### PR DESCRIPTION
**Severity:** HIGH
**Vulnerability:** A client-side Denial of Service (DoS) vulnerability existed because there was no upper limit enforced on the total cumulative number of pages processed across all uploaded PDFs. While individual files were capped at 32 pages, a user could sequentially upload multiple PDFs. These would be entirely parsed and looped over in `processAdditionalPDF`, causing excessive memory allocation for `this.allPageImages`, massive canvas rendering queues, and ultimately crashing the browser.
**Impact:** A malicious user or a script could upload a sequence of PDFs that collectively exceed the browser's memory and DOM handling capacity, freezing or crashing the client application.
**Fix:** Enforced a strict maximum limit (`ABSOLUTE_MAX_PAGES = 100`) on the cumulative page count (`this.totalPages`) early in the processing logic of `processAdditionalPDF`. If adding a new PDF pushes the total over this limit, the processing is aborted, a user-friendly error is shown, and the rejected file is cleaned out of the `uploadedFiles` array to maintain a consistent UI state.
**Verification:** Run `pnpm test` to verify that existing security and functionality tests continue to pass. The UI handles the rejection smoothly without stranding "ghost" files in the uploaded queue.

---
*PR created automatically by Jules for task [1907165440996102642](https://jules.google.com/task/1907165440996102642) started by @guitarbeat*

## Summary by Sourcery

Enforce a hard upper bound on the total number of PDF pages that can be processed in the client to prevent resource exhaustion and ensure failed uploads are correctly removed from the UI.

Bug Fixes:
- Prevent client-side DoS by capping the cumulative number of processed PDF pages at 100 across all uploads.
- Ensure PDFs that fail processing are removed from the uploaded files list so the UI remains consistent.