### PR TITLE
🎨 Palette: Add aria-label to icon-only buttons in Template

### DIFF
--- a/src/components/UI/Templates.js
+++ b/src/components/UI/Templates.js
@@ -7,16 +7,16 @@ export const PAGE_CELL_TEMPLATE = document.createElement('template');
 PAGE_CELL_TEMPLATE.innerHTML = `
   <span class="page-label"></span>
   <div class="page-toolbar absolute top-2 right-2 flex flex-wrap justify-end gap-2 z-10 max-w-[calc(100%-1rem)] transition-opacity duration-200 opacity-0 group-hover:opacity-100 focus-within:opacity-100" data-layout="row">
-     <button class="zoom-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Quick Preview (Z)">
+     <button class="zoom-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" aria-label="Quick Preview (Z)" title="Quick Preview (Z)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">zoom_in</span>
      </button>
-     <button class="crop-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Toggle Crop/Zoom (C)">
+     <button class="crop-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" aria-label="Toggle Crop/Zoom (C)" title="Toggle Crop/Zoom (C)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">crop_free</span>
      </button>
-     <button class="flip-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Flip 180° (R)">
+     <button class="flip-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" aria-label="Flip 180° (R)" title="Flip 180° (R)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">rotate_right</span>
      </button>
-     <button class="remove-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-red-500 hover:text-white" style="box-shadow: var(--shadow-sm);" title="Remove Page (Backspace)">
+     <button class="remove-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-red-500 hover:text-white" style="box-shadow: var(--shadow-sm);" aria-label="Remove Page (Backspace)" title="Remove Page (Backspace)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">close</span>
      </button>
   </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the icon-only buttons in the page cell template.
🎯 **Why:** Icon-only buttons without an accessible name are difficult for screen-reader users to understand. Adding `aria-label` makes them fully accessible.
📸 **Before/After:** No visual changes, only markup updates.
♿ **Accessibility:** Screen-readers can now accurately announce the function of the Quick Preview, Toggle Crop/Zoom, Flip 180°, and Remove Page buttons in the layout view.

---
*PR created automatically by Jules for task [97360399643300228](https://jules.google.com/task/97360399643300228) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Improve accessibility of Quick Preview, Crop/Zoom, Flip, and Remove buttons by adding aria-label attributes matching their actions.