### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Error Data Exposure by sanitizing console.error

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-15 - Prevent Error Data Exposure by sanitizing console.error
+**Vulnerability:** The application was logging raw `Error` objects directly to the browser console (`console.error(error)`) during initialization failures.
+**Learning:** Raw `Error` objects can contain sensitive stack traces, file paths, and internal application metadata that could be exposed to third-party scripts, browser extensions, or malicious users inspecting the console, leading to Information Disclosure (Error Data Exposure).
+**Prevention:** Always sanitize errors before logging them to the client-side console in production environments, extracting and logging only safe, user-facing properties like `error.message` or using a generic fallback string.

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -36,7 +36,7 @@ export class AppController {
     } catch (error) {
       toast.error('Initialization Failed', 'Check console for details.');
       // eslint-disable-next-line no-console
-      console.error(error);
+      console.error(error.message || 'Initialization error');
     }
   }
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Error Data Exposure. The application was logging raw `Error` objects directly to the browser console during initialization failures.
🎯 **Impact:** Raw `Error` objects contain stack traces and internal application metadata that could leak sensitive architecture details to the client-side console, accessible by third-party scripts or malicious users.
🔧 **Fix:** Sanitized the `console.error` call in `src/core/AppController.js` to only log `error.message` or a generic fallback string instead of the raw `Error` object.
✅ **Verification:** Ran `pnpm lint`, `pnpm build`, and the test suite to ensure the change does not break functionality and safely handles errors.

---
*PR created automatically by Jules for task [15389930756568543158](https://jules.google.com/task/15389930756568543158) started by @guitarbeat*

## Summary by Sourcery

Sanitize initialization error logging to avoid exposing raw error details in the browser console.

Bug Fixes:
- Prevent exposure of full Error objects in console output during application initialization failures.

Documentation:
- Add a Sentinel security note documenting the error data exposure issue and recommended logging practices.