### PR TITLE
🎨 Palette: Improve keyboard focus visibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-14 - Icon-only modal close buttons missing ARIA labels
 **Learning:** Icon-only modal close buttons (like the 3D preview and page picker close buttons) often miss `aria-label` and `title` attributes, making them inaccessible to screen readers and lacking tooltips for mouse users. Even dynamically generated modals (like the zoom preview modal in `ModalManager.js`) need these attributes explicitly defined in their HTML template strings.
 **Action:** Always ensure that icon-only interactive elements (`<button>`, `<a>`) have clear, descriptive `aria-label` and `title` attributes, regardless of whether they are hardcoded in the main HTML file or generated dynamically via JavaScript.
+
+## 2024-05-18 - Improve Keyboard Focus Visibility
+**Learning:** Suppressing focus outlines with `focus:outline-none` harms accessibility for keyboard users, making it impossible to see which element is currently focused.
+**Action:** Always use high-contrast focus rings (like `focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed ...`) for interactive elements instead of disabling focus outlines entirely.

--- a/src/components/UI/Templates.js
+++ b/src/components/UI/Templates.js
@@ -7,16 +7,16 @@ export const PAGE_CELL_TEMPLATE = document.createElement('template');
 PAGE_CELL_TEMPLATE.innerHTML = `
   <span class="page-label"></span>
   <div class="page-toolbar absolute top-2 right-2 flex flex-wrap justify-end gap-2 z-10 max-w-[calc(100%-1rem)] transition-opacity duration-200 opacity-0 group-hover:opacity-100 focus-within:opacity-100" data-layout="row">
-     <button class="zoom-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Quick Preview (Z)">
+     <button class="zoom-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Quick Preview (Z)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">zoom_in</span>
      </button>
-     <button class="crop-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Toggle Crop/Zoom (C)">
+     <button class="crop-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Toggle Crop/Zoom (C)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">crop_free</span>
      </button>
-     <button class="flip-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Flip 180° (R)">
+     <button class="flip-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Flip 180° (R)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">rotate_right</span>
      </button>
-     <button class="remove-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-red-500 hover:text-white" style="box-shadow: var(--shadow-sm);" title="Remove Page (Backspace)">
+     <button class="remove-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black hover:bg-red-500 hover:text-white" style="box-shadow: var(--shadow-sm);" title="Remove Page (Backspace)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">close</span>
      </button>
   </div>

--- a/tests/e2e/accessibility_buttons.spec.js
+++ b/tests/e2e/accessibility_buttons.spec.js
@@ -6,13 +6,13 @@ test('toolbar buttons have accessible labels and focus states', async ({ page })
 
   const coverZoomBtn = page.locator('button[aria-label^="Quick Preview"]').first();
   await expect(coverZoomBtn).toHaveAttribute('aria-label', /Quick Preview/);
-  await expect(coverZoomBtn).toHaveClass(/focus:outline-none/);
+  await expect(coverZoomBtn).toHaveClass(/focus-visible:outline-4/);
 
   const coverCropBtn = page.locator('button[aria-label^="Toggle Crop\\/Zoom"]').first();
   await expect(coverCropBtn).toHaveAttribute('aria-label', /Toggle Crop\/Zoom/);
-  await expect(coverCropBtn).toHaveClass(/focus:outline-none/);
+  await expect(coverCropBtn).toHaveClass(/focus-visible:outline-4/);
 
   const coverRemoveBtn = page.locator('button[aria-label^="Remove"]').first();
   await expect(coverRemoveBtn).toHaveAttribute('aria-label', /Remove/);
-  await expect(coverRemoveBtn).toHaveClass(/focus:outline-none/);
+  await expect(coverRemoveBtn).toHaveClass(/focus-visible:outline-4/);
 });


### PR DESCRIPTION
**💡 What:** Replaced `focus:outline-none` with high-contrast `focus-visible:outline-4` styles on the page toolbar action buttons (Zoom, Crop, Flip, Remove). 
**🎯 Why:** Disabling focus outlines completely removes visual feedback for keyboard users, making it impossible to know which button is currently selected when tabbing through the interface. This restores a clear, punk-themed focus ring that matches the rest of the application's aesthetic.
**📸 Before/After:** Before, tabbing to a toolbar button showed nothing. After, tabbing shows a thick black dashed outline with a yellow background (`!bg-yellow-300`).
**♿ Accessibility:** Massively improves keyboard navigation by restoring visible focus indicators, allowing users who rely on keyboards to confidently operate the page toolbar.

---
*PR created automatically by Jules for task [17162770283694587696](https://jules.google.com/task/17162770283694587696) started by @guitarbeat*

## Summary by Sourcery

Improve keyboard focus visibility and accessibility for page toolbar action buttons and document the associated accessibility guideline.

New Features:
- Add prominent focus-visible styles to page toolbar action buttons (zoom, crop, flip, remove) to provide a high-contrast keyboard focus indicator.

Enhancements:
- Update accessibility end-to-end tests to assert the new focus-visible styling on toolbar buttons.

Documentation:
- Extend the Palette accessibility guidelines with a note discouraging suppression of focus outlines and recommending high-contrast focus rings for interactive elements.