### PR TITLE
🛡️ Sentinel: [Medium] Fix Error Data Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2026-04-16 - Prevent Error Data Exposure
+
+**Vulnerability:** The application was logging raw Error objects via `console.error` directly to the client browser console.
+**Learning:** This could expose sensitive internal metadata or stack traces to any user observing the console logs, leading to potential data leakage.
+**Prevention:** Always sanitize console logs (`console.error`, `console.warn`) in production-facing client-side code by logging only a generic message or `error.message`.

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -36,7 +36,7 @@ export class AppController {
     } catch (error) {
       toast.error('Initialization Failed', 'Check console for details.');
       // eslint-disable-next-line no-console
-      console.error(error);
+      console.error(error.message || 'Initialization error');
     }
   }
 


### PR DESCRIPTION
🚨 **Severity:** Medium
💡 **Vulnerability:** The application was logging raw Error objects directly to the client console via `console.error(error)` during initialization failures.
🎯 **Impact:** This exposes sensitive internal metadata and stack traces to users or extensions observing the browser console, leading to potential data leakage and reconnaissance.
🔧 **Fix:** Extracted `error.message` with a fallback string, ensuring only generic, sanitized details are logged instead of the full `Error` object. Added `.jules/sentinel.md` entry.
✅ **Verification:** Verified that tests pass and the specific logging logic is properly modified to use `error.message`.

---
*PR created automatically by Jules for task [7583332100139869657](https://jules.google.com/task/7583332100139869657) started by @guitarbeat*

## Summary by Sourcery

Sanitize initialization error logging to avoid exposing internal error details in the browser console and document the security fix in Sentinel notes.

Bug Fixes:
- Prevent exposure of full Error objects and stack traces in client console logs during initialization failures.

Documentation:
- Add Sentinel security note describing the prior error logging vulnerability and recommended logging practices.