### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in sanitizeHTML

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Error Data Exposure through client-side console logging (stack traces, internal variables).
 **Learning:** Raw Error objects passed to console.error() expose deep application stack traces to users and potential attackers, revealing application internals.
 **Prevention:** Only log error.message or a safe generic string, rather than the raw Error object in production-facing client code.
+
+## 2026-04-23 - Prevent DOM Clobbering/XSS in Sanitizer
+**Vulnerability:** Safe HTML sanitization using `template.innerHTML` could potentially trigger execution of payload (e.g. `img` `onerror`) before sanitization takes place if assigned directly.
+**Learning:** Assigning unsafe strings to `innerHTML`, even on detached template tags, has inherent risks. Using `DOMParser` parses the string into a safe document object model without evaluating executing elements.
+**Prevention:** Use `new DOMParser().parseFromString(html, 'text/html')` for safe DOM element creation during sanitization instead of `innerHTML` assignment.

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -74,8 +74,8 @@ export function sanitizeHTML(html) {
     return fragment;
   }
 
-  const template = document.createElement('template');
-  template.innerHTML = html;
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
 
   const allowedTags = new Set(['B', 'STRONG', 'I', 'EM', 'U', 'BR', 'CODE', 'SPAN']);
 
@@ -100,7 +100,7 @@ export function sanitizeHTML(html) {
     return cleanElement;
   };
 
-  Array.from(template.content.childNodes).forEach((child) => {
+  Array.from(doc.body.childNodes).forEach((child) => {
     fragment.appendChild(sanitizeNode(child));
   });
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential Cross-Site Scripting (XSS) / DOM Clobbering vulnerability due to `innerHTML` assignment of user-supplied HTML strings inside `sanitizeHTML`, which could trigger early execution (e.g., via `img onerror` handlers) before the sanitization rules could process the DOM tree.
🎯 Impact: Attackers could potentially execute arbitrary JavaScript in the context of the user's browser, leading to session hijacking, data theft, or UI defacement.
🔧 Fix: Replaced `template.innerHTML` with `DOMParser.parseFromString(html, 'text/html')` to safely parse HTML into a DOM document without evaluating elements, ensuring sanitization completes safely.
✅ Verification: Ran unit tests for utils and security xss spec suite. All tests pass successfully and verify DOM execution paths.

---
*PR created automatically by Jules for task [7513905404019552023](https://jules.google.com/task/7513905404019552023) started by @guitarbeat*

## Summary by Sourcery

Mitigate an XSS/DOM clobbering risk in the HTML sanitizer by switching to safe DOM parsing and document the security change in Sentinel notes.

Bug Fixes:
- Prevent potential XSS and DOM clobbering during HTML sanitization by parsing untrusted HTML with DOMParser instead of assigning it to a template element's innerHTML.

Documentation:
- Add Sentinel security note describing the DOMParser-based mitigation for sanitizer-related XSS risks.