### PR TITLE
security: replace .innerHTML with safe DOM manipulation in page picker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Error Data Exposure through client-side console logging (stack traces, internal variables).
 **Learning:** Raw Error objects passed to console.error() expose deep application stack traces to users and potential attackers, revealing application internals.
 **Prevention:** Only log error.message or a safe generic string, rather than the raw Error object in production-facing client code.
+
+## 2026-04-23 - Avoid .innerHTML for dynamic content
+**Vulnerability:** Potential Cross-Site Scripting (XSS) via .innerHTML with dynamic content.
+**Learning:** Using .innerHTML with dynamic data, even if currently sourced locally, is a risky practice that can lead to XSS if the data source becomes untrusted or compromised.
+**Prevention:** Always use safe DOM manipulation methods like document.createElement, textContent, and setAttribute to handle dynamic content.

--- a/src/components/UI/ModalManager.js
+++ b/src/components/UI/ModalManager.js
@@ -128,15 +128,29 @@ export class ModalManager {
       button.className = 'page-picker-thumb';
       button.dataset.pageNumber = String(pageNumber);
       button.setAttribute('aria-pressed', initialSelection.includes(pageNumber) ? 'true' : 'false');
-      button.innerHTML = `
-        <div class="page-picker-thumb-media">
-          <img src="${thumbnailUrl}" alt="PDF page ${pageNumber}">
-        </div>
-        <div class="page-picker-thumb-page">
-          <span>Page ${pageNumber}</span>
-          <span class="page-picker-thumb-order" aria-hidden="true"></span>
-        </div>
-      `;
+      const mediaDiv = document.createElement('div');
+      mediaDiv.className = 'page-picker-thumb-media';
+
+      const img = document.createElement('img');
+      img.src = thumbnailUrl;
+      img.alt = `PDF page ${pageNumber}`;
+      mediaDiv.appendChild(img);
+
+      const pageDiv = document.createElement('div');
+      pageDiv.className = 'page-picker-thumb-page';
+
+      const pageSpan = document.createElement('span');
+      pageSpan.textContent = `Page ${pageNumber}`;
+
+      const orderSpan = document.createElement('span');
+      orderSpan.className = 'page-picker-thumb-order';
+      orderSpan.setAttribute('aria-hidden', 'true');
+
+      pageDiv.appendChild(pageSpan);
+      pageDiv.appendChild(orderSpan);
+
+      button.appendChild(mediaDiv);
+      button.appendChild(pageDiv);
       button.addEventListener('click', () => this.togglePageSelection(pageNumber));
       this.elements.pagePickerGrid.appendChild(button);
     });


### PR DESCRIPTION
security: replace .innerHTML with safe DOM manipulation in page picker

This change replaces the use of .innerHTML when rendering the page picker grid
to prevent potential XSS vulnerabilities. It uses document.createElement,
textContent, and setAttribute to safely build the DOM structure.

---
Created from Jules session `sessions/17551531117153969728`
Jules URL: https://jules.google.com/session/17551531117153969728

## Summary by Sourcery

Replace innerHTML-based rendering in the page picker modal with explicit DOM element construction to improve security and document the guideline in the security sentinel notes.

Enhancements:
- Refine page picker button rendering to use createElement, textContent, and setAttribute instead of innerHTML for safer DOM updates.

Documentation:
- Add security guidance discouraging innerHTML for dynamic content and recommending safe DOM manipulation patterns.