### PR TITLE
🛡️ Sentinel: [low] fix error data exposure in PDF processing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -38,6 +38,11 @@
 **Learning:** A robust client-side tool CSP must explicitly deny obsolete/dangerous features like plugins and ensure that relative URLs and form submissions remain bound to the application's origin, even if the application doesn't currently use forms or plugins.
 **Prevention:** Always include `object-src 'none'`, `base-uri 'self'`, and `form-action 'self'` in the initial CSP configuration as a defense-in-depth measure.
 
+## 2025-02-14 - [Error Data Exposure in PDF Processing]
+**Vulnerability:** The application was logging full `Error` objects to the browser console during PDF processing failures. These objects can contain sensitive metadata, stack traces, and internal state that could be leveraged by an attacker to map the application's internal structure or discover other vulnerabilities.
+**Learning:** Logging entire error objects in production-facing client-side code is a security risk. While useful for debugging, stack traces and detailed error metadata should never be exposed to the user or the console in a production environment.
+**Prevention:** Always sanitize error logs by extracting only the necessary information, such as `error.message`, and provide a generic fallback message if the message is unavailable. Avoid passing the full error object to `console.error` or other logging mechanisms in client-side code.
+
 ## 2025-02-14 - [Client-Side DoS via Unbounded File Uploads]
 **Vulnerability:** The application allowed an arbitrary number of PDF files to be uploaded simultaneously via both the file input and drag-and-drop mechanisms. Malicious users or unintended actions could upload hundreds of files at once, leading to excessive memory consumption, UI freezing, and ultimately a Denial of Service (DoS) in the client browser.
 **Learning:** Event handlers processing user-supplied data (such as `change` events on file inputs or `drop` events) must independently enforce limits on the size and quantity of data processed. Assuming users will only upload reasonable amounts of files is a security risk.

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -35,7 +35,7 @@ class PDFZineMaker {
       this.ui.generateLayout(8); // Default to 8 pages
       this.ui.setStatus('Upload PDF files to get started', 'info');
     } catch (error) {
-      console.error('Initialization error:', error);
+      console.error('Initialization error:', error.message || 'Unknown error during initialization');
       this.ui.setStatus('Failed to initialize. Please refresh the page.', 'error');
       toast.error('Initialization Error', 'Failed to load required libraries.');
     }
@@ -110,7 +110,7 @@ class PDFZineMaker {
       try {
         URL.revokeObjectURL(oldUrl);
       } catch (e) {
-        console.warn('Failed to revoke URL:', e);
+        console.warn('Failed to revoke URL:', e.message || 'Unknown error during URL revocation');
       }
     }
 
@@ -295,7 +295,7 @@ class PDFZineMaker {
       toast.success('Done!', 'Your zine is ready to print.');
 
     } catch (error) {
-      console.error('PDF Error:', error);
+      console.error('PDF Error:', error.message || 'An error occurred during PDF processing');
       this.ui.showProgress(false);
       toast.error('Error', error.message || 'Failed to process PDF.');
     }
@@ -641,7 +641,7 @@ class PDFZineMaker {
       doc.save(`zine-${Date.now()}.pdf`);
       toast.success('Downloaded!', 'Your PDF is ready.');
     } catch (e) {
-      console.error(e);
+      console.error('Export Failed:', e.message || 'Unknown error during export');
       toast.error('Export Failed', 'Something went wrong.');
     } finally {
       this.ui.elements.exportPdfBtn.disabled = false;

--- a/src/js/pdf-processor.js
+++ b/src/js/pdf-processor.js
@@ -125,7 +125,7 @@ export class PDFProcessor {
       };
 
     } catch (error) {
-      console.error('PDF loading error:', error);
+      console.error('PDF loading error:', error.message || 'Unknown loading error');
       throw this.handlePDFError(error);
     } finally {
       this.isProcessing = false;
@@ -202,7 +202,7 @@ export class PDFProcessor {
       return canvas;
 
     } catch (error) {
-      console.error(`Failed to render page ${pageNum}:`, error);
+      console.error(`Failed to render page ${pageNum}:`, error.message || 'Unknown rendering error');
       throw new Error(`Failed to render page ${pageNum}`, { cause: error });
     }
   }
@@ -250,7 +250,7 @@ export class PDFProcessor {
       const dataUrl = canvas.toDataURL(format, quality);
       return dataUrl;
     } catch (error) {
-      console.warn(`Failed to generate ${format}, falling back to PNG:`, error);
+      console.warn(`Failed to generate ${format}, falling back to PNG:`, error.message || 'Unknown error');
       // Fallback to PNG if JPEG fails
       return canvas.toDataURL('image/png', 1.0);
     }

--- a/tests/security/error_exposure.spec.js
+++ b/tests/security/error_exposure.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { spawn } from 'child_process';
+
+test.describe.configure({ mode: 'serial' });
+
+let server;
+const PORT = 3005;
+
+test.beforeAll(async () => {
+  server = spawn('pnpm', ['dev', '--port', PORT.toString()], {
+    stdio: 'ignore',
+    shell: true,
+    detached: true
+  });
+  await new Promise(resolve => setTimeout(resolve, 3000));
+});
+
+test.afterAll(() => {
+  if (server) {
+    try { process.kill(-server.pid); } catch (e) {}
+  }
+});
+
+test('Should not leak full error object/stack trace in console on PDF error', async ({ page }) => {
+  const consoleErrors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      consoleErrors.push(msg.text());
+    }
+  });
+
+  await page.goto(`http://localhost:${PORT}`);
+
+  // Create a file with valid PDF signature but invalid content to trigger a processing error
+  const buffer = Buffer.from('%PDF-1.7\nNOT_A_VALID_PDF_BODY');
+
+  const fileInput = page.locator('#pdf-upload');
+
+  await fileInput.setInputFiles({
+    name: 'corrupted.pdf',
+    mimeType: 'application/pdf',
+    buffer: buffer
+  });
+
+  // Wait for the error toast to appear
+  const toastMessage = page.locator('#toast-container');
+  await expect(toastMessage).toContainText('Error', { timeout: 10000 });
+
+  // Verify that console error contains the prefix but NOT a full object representation or stack trace
+  // When an object is logged, msg.text() often shows [object Object] or similar depending on environment
+  
+  const pdfErrorLog = consoleErrors.find(log => log.startsWith('PDF Error:'));
+  expect(pdfErrorLog).toBeDefined();
+  
+  // It should be a string, and specifically it should NOT contain common stack trace indicators if it was just the message
+  expect(pdfErrorLog).not.toContain('[object Object]');
+  
+  const loadingErrorLog = consoleErrors.find(log => log.startsWith('PDF loading error:'));
+  expect(loadingErrorLog).toBeDefined();
+  expect(loadingErrorLog).not.toContain('[object Object]');
+});


### PR DESCRIPTION
🛡️ Sentinel: [low] fix error data exposure in PDF processing

Fixed several instances where full Error objects were logged to the console, potentially leaking sensitive metadata and stack traces. Sanitized logs to only include error messages.

- Updated src/js/main.js and src/js/pdf-processor.js
- Added tests/security/error_exposure.spec.js
- Updated .jules/sentinel.md

---
Created from Jules session `sessions/4557849937711623293`
Jules URL: https://jules.google.com/session/4557849937711623293

## Summary by Sourcery

Sanitize PDF processing error logging to avoid exposing full error objects and sensitive details in the browser console.

Bug Fixes:
- Restrict console logging in PDF initialization, processing, URL revocation, and export flows to error messages or generic fallbacks instead of full Error objects.
- Limit PDF processor console logs to concise error messages to prevent leaking stack traces or internal metadata.

Documentation:
- Document the error data exposure vulnerability, its impact, and preventive logging practices in the Sentinel security notes.

Tests:
- Add a Playwright security test that triggers a PDF processing failure and asserts that console error output does not contain full error object representations or stack traces.