### PR TITLE
🛡️ Sentinel: Fix PDF.js cMaps version mismatch and CSP restriction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2026-04-16 - PDF.js cMaps Version Mismatch and CSP Restriction
+
+**Vulnerability:** External Dependency Version Mismatch for cMaps. The application was missing explicit cMap configuration, and a potential hardcoded or default CDN link would have caused a version mismatch with the core `pdfjs-dist` library (5.4.624). Furthermore, the Content Security Policy (CSP) did not permit connections to `https://cdn.jsdelivr.net`, which is required for fetching external cMaps used in character mapping for certain PDF files.
+
+**Learning:** PDF.js requires cMaps to correctly render PDFs that use non-standard font encodings. When these are fetched from a CDN, the version of the cMaps must exactly match the version of the `pdfjs-dist` library being used. Additionally, the CSP must be explicitly configured to allow the connection to the CDN provider.
+
+**Prevention:** Always pin external assets fetched via CDN to the exact version of the corresponding local dependency. Maintain a strict but functional CSP that explicitly whitelists necessary external resources.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
     <meta name="description" content="Import pages, arrange a printable zine sheet, preview the fold, and export." />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; worker-src 'self' blob:; connect-src 'self' ws: http://localhost:8001 http://127.0.0.1:8001 blob:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; worker-src 'self' blob:; connect-src 'self' ws: http://localhost:8001 http://127.0.0.1:8001 blob: https://cdn.jsdelivr.net;">
     <title>Zine-ify — Single-Sheet Zine Layout</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />

--- a/src/services/PDFProcessor.js
+++ b/src/services/PDFProcessor.js
@@ -99,6 +99,8 @@ export class PDFProcessor extends MediaProcessor {
 
       this.loadingTask = pdfjsLib.getDocument({
         url: this.fileUrl,
+        cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@5.4.624/cmaps/',
+        cMapPacked: true,
         verbosity: 0,
         enableScripting: false,
         isEvalSupported: false


### PR DESCRIPTION
🛡️ Sentinel: Fix PDF.js cMaps version mismatch and CSP restriction

- Pin cMapUrl to match pdfjs-dist version 5.4.624
- Add https://cdn.jsdelivr.net to connect-src CSP directive
- Document security fix in .jules/sentinel.md

---
Created from Jules session `sessions/5930520680982701059`
Jules URL: https://jules.google.com/session/5930520680982701059

## Summary by Sourcery

Address PDF.js external cMap loading compatibility and related security policy configuration.

Bug Fixes:
- Align PDF.js cMap loading with the bundled pdfjs-dist version by explicitly pinning the cMap CDN URL and enabling packed cMaps.
- Allow PDF.js to fetch cMaps from the CDN by extending the Content Security Policy connect-src directive to include cdn.jsdelivr.net.

Documentation:
- Add a Sentinel security note documenting the PDF.js cMaps version mismatch issue and the required CSP allowance for the CDN.