### PR TITLE
🎨 Palette: Add accessible, high-contrast focus rings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-14 - Icon-only modal close buttons missing ARIA labels
 **Learning:** Icon-only modal close buttons (like the 3D preview and page picker close buttons) often miss `aria-label` and `title` attributes, making them inaccessible to screen readers and lacking tooltips for mouse users. Even dynamically generated modals (like the zoom preview modal in `ModalManager.js`) need these attributes explicitly defined in their HTML template strings.
 **Action:** Always ensure that icon-only interactive elements (`<button>`, `<a>`) have clear, descriptive `aria-label` and `title` attributes, regardless of whether they are hardcoded in the main HTML file or generated dynamically via JavaScript.
+
+## 2024-04-14 - Inaccessible focus rings
+**Learning:** Using `focus:outline-none` removes the default browser focus ring, making keyboard navigation difficult or impossible to track for interactive elements like buttons and upload boxes.
+**Action:** Replace `focus:outline-none` with high-contrast, accessible focus indicators (e.g., `focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black`) to ensure clear visibility during keyboard navigation.

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                         </div>
 
                         <div id="upload-zone"
-                            class="upload-box relative overflow-hidden px-4 py-5 sm:p-6 flex flex-col items-center justify-center text-center cursor-pointer min-h-[128px] sm:min-h-[140px] group focus:outline-none"
+                            class="upload-box relative overflow-hidden px-4 py-5 sm:p-6 flex flex-col items-center justify-center text-center cursor-pointer min-h-[128px] sm:min-h-[140px] group focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black"
                             role="button" tabindex="0" aria-label="Upload PDF or image files" title="Upload PDFs or images (Ctrl+O)" aria-keyshortcuts="Control+O">
                             <span class="material-symbols-outlined text-4xl mb-3" style="color: var(--primary-vibrant);" aria-hidden="true">cloud_upload</span>
                             <h2 class="font-marker text-base sm:text-lg leading-tight mb-1">Add a PDF or image set</h2>
@@ -272,7 +272,7 @@
                         <span class="simulation-meta-chip">Keys 1-6 = steps</span>
                     </div>
                 </div>
-                <button id="close-3d-btn" class="action-button simulation-close-btn bg-white text-black font-bold focus:outline-none" type="button" aria-label="Close 3D preview" title="Close 3D preview">
+                <button id="close-3d-btn" class="action-button simulation-close-btn bg-white text-black font-bold focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black" type="button" aria-label="Close 3D preview" title="Close 3D preview">
                     <span class="material-symbols-outlined text-xl" aria-hidden="true">close</span>
                 </button>
             </div>

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -63,7 +63,7 @@ class Toast {
     }
 
     const closeBtn = document.createElement('button');
-    closeBtn.className = 'toast-close w-6 h-6 ml-2 flex items-center justify-center focus:outline-none';
+    closeBtn.className = 'toast-close w-6 h-6 ml-2 flex items-center justify-center focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black';
     closeBtn.setAttribute('aria-label', 'Close notification');
     closeBtn.innerHTML = '&times;'; // Safe entity
     closeBtn.addEventListener('click', () => this.remove(toast));

--- a/src/components/UI/ModalManager.js
+++ b/src/components/UI/ModalManager.js
@@ -241,7 +241,7 @@ export class ModalManager {
         <div class="relative w-11/12 h-11/12 max-w-7xl max-h-[90vh] bg-white overflow-hidden flex flex-col scale-95 transition-transform duration-300" style="border: 3px solid black; box-shadow: 6px 6px 0px 0px black;">
           <div class="flex justify-between items-center px-4 py-2 border-b-2 border-black">
             <h3 class="font-bold uppercase tracking-wider text-sm">Page Preview</h3>
-            <button class="close-modal w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center hover:bg-red-500 hover:text-white transition-colors focus:outline-none" style="box-shadow: 2px 2px 0px 0px black;" aria-label="Close page preview" title="Close page preview">
+            <button class="close-modal w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center hover:bg-red-500 hover:text-white transition-colors focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black" style="box-shadow: 2px 2px 0px 0px black;" aria-label="Close page preview" title="Close page preview">
               <span class="material-symbols-outlined font-bold" aria-hidden="true">close</span>
             </button>
           </div>

--- a/src/components/UI/Templates.js
+++ b/src/components/UI/Templates.js
@@ -7,16 +7,16 @@ export const PAGE_CELL_TEMPLATE = document.createElement('template');
 PAGE_CELL_TEMPLATE.innerHTML = `
   <span class="page-label"></span>
   <div class="page-toolbar absolute top-2 right-2 flex flex-wrap justify-end gap-2 z-10 max-w-[calc(100%-1rem)] transition-opacity duration-200 opacity-0 group-hover:opacity-100 focus-within:opacity-100" data-layout="row">
-     <button class="zoom-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Quick Preview (Z)">
+     <button class="zoom-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Quick Preview (Z)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">zoom_in</span>
      </button>
-     <button class="crop-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Toggle Crop/Zoom (C)">
+     <button class="crop-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Toggle Crop/Zoom (C)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">crop_free</span>
      </button>
-     <button class="flip-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Flip 180° (R)">
+     <button class="flip-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black hover:bg-[var(--primary-vibrant)] hover:text-white" style="box-shadow: var(--shadow-sm);" title="Flip 180° (R)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">rotate_right</span>
      </button>
-     <button class="remove-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus:outline-none hover:bg-red-500 hover:text-white" style="box-shadow: var(--shadow-sm);" title="Remove Page (Backspace)">
+     <button class="remove-btn w-8 h-8 bg-white border-2 border-black text-black flex items-center justify-center transition-all duration-100 focus-visible:outline-4 focus-visible:outline-black focus-visible:outline-dashed focus-visible:outline-offset-4 focus-visible:!bg-yellow-300 focus-visible:!text-black hover:bg-red-500 hover:text-white" style="box-shadow: var(--shadow-sm);" title="Remove Page (Backspace)">
           <span class="material-symbols-outlined text-[18px]" aria-hidden="true">close</span>
      </button>
   </div>

--- a/tests/e2e/accessibility_buttons.spec.js
+++ b/tests/e2e/accessibility_buttons.spec.js
@@ -6,13 +6,13 @@ test('toolbar buttons have accessible labels and focus states', async ({ page })
 
   const coverZoomBtn = page.locator('button[aria-label^="Quick Preview"]').first();
   await expect(coverZoomBtn).toHaveAttribute('aria-label', /Quick Preview/);
-  await expect(coverZoomBtn).toHaveClass(/focus:outline-none/);
+  await expect(coverZoomBtn).toHaveClass(/focus-visible:outline-4/);
 
   const coverCropBtn = page.locator('button[aria-label^="Toggle Crop\\/Zoom"]').first();
   await expect(coverCropBtn).toHaveAttribute('aria-label', /Toggle Crop\/Zoom/);
-  await expect(coverCropBtn).toHaveClass(/focus:outline-none/);
+  await expect(coverCropBtn).toHaveClass(/focus-visible:outline-4/);
 
   const coverRemoveBtn = page.locator('button[aria-label^="Remove"]').first();
   await expect(coverRemoveBtn).toHaveAttribute('aria-label', /Remove/);
-  await expect(coverRemoveBtn).toHaveClass(/focus:outline-none/);
+  await expect(coverRemoveBtn).toHaveClass(/focus-visible:outline-4/);
 });


### PR DESCRIPTION
**💡 What:** Replaced inaccessible `focus:outline-none` styles with clear, high-contrast, punk-themed `focus-visible` indicators across interactive elements.
**🎯 Why:** Users navigating via keyboard could not see which interactive elements (like modal close buttons, toolbar tools, and the upload dropzone) currently had focus. This prevents keyboard trapping and confusion.
**📸 Before/After:** Visually identical to mouse users. Keyboard users now see a thick, dashed, high-contrast yellow-and-black focus ring. 
**♿ Accessibility:** Greatly improves keyboard navigation visibility (WCAG 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [11851294589639831770](https://jules.google.com/task/11851294589639831770) started by @guitarbeat*

## Summary by Sourcery

Improve keyboard focus visibility across interactive UI elements with high-contrast focus-visible styles.

Enhancements:
- Replace removal of browser focus outlines with consistent, high-contrast focus-visible rings on toolbar buttons, upload dropzone, toast close button, modal close buttons, and 3D preview close control.

Documentation:
- Add palette guidance documenting the accessibility issue with focus:outline-none and our preferred accessible focus-visible pattern.

Tests:
- Update accessibility end-to-end tests to assert the presence of the new focus-visible outline classes on toolbar buttons.