### PR TITLE
🧹 Fix swallowed catch error in PDFProcessor

### DIFF
--- a/src/services/PDFProcessor.js
+++ b/src/services/PDFProcessor.js
@@ -350,7 +350,7 @@ export class PDFProcessor extends MediaProcessor {
    * Clean up resources
    */
   cleanup() {
-    this.loadingTask?.destroy().catch(() => {});
+    this.loadingTask?.destroy().catch((error) => console.warn('Error destroying PDF loading task:', error));
     this.loadingTask = null;
     if (this.pdf) {
       this.pdf.destroy();


### PR DESCRIPTION
🎯 **What:** The catch block for destroying the PDF loading task silently swallowed errors. It has been updated to log the error.
💡 **Why:** Silently swallowing errors hides potential failures during resource cleanup, making debugging more difficult. Logging the error improves maintainability and visibility into resource management issues.
✅ **Verification:** Verified the code changes locally using git diff. Ran the test suite to ensure no new regressions were introduced by this isolated change.
✨ **Result:** The code now properly logs cleanup errors, improving debuggability and code health.

---
*PR created automatically by Jules for task [173307652019929264](https://jules.google.com/task/173307652019929264) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Ensure errors from destroying the PDF loading task are surfaced via console warnings rather than being ignored.