### PR TITLE
🔒 Sentinel: [Low] Fix Insecure File Extension Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -20,3 +20,9 @@
 ## 2026-05-12 - [Test Dependency Added]
 **Learning:** Testing DOM manipulation in Node using JSDOM is effective but introduces `jsdom` dependency.
 **Action:** Monitored package updates carefully, added it cleanly without compromising build artifacts.
+## 2024-05-12 - [Insecure File Extension Validation]
+**Learning:** Relying solely on the  MIME string for client-side file validation is inherently insecure as it is easily spoofed by malicious actors renaming a script or executable to have a  extension.
+**Action:** Always implement defense-in-depth by enforcing a strict file extension allowlist via  parsing to complement any primary MIME type checks, ensuring consistency between stated type and extension.
+## 2026-05-12 - [Insecure File Extension Validation]
+**Learning:** Relying solely on the `file.type` MIME string for client-side file validation is inherently insecure as it is easily spoofed by malicious actors renaming a script or executable.
+**Action:** Always implement defense-in-depth by enforcing a strict file extension allowlist via `file.name` parsing to complement any primary MIME type checks, ensuring consistency between stated type and extension.

--- a/src/utils/fileValidation.js
+++ b/src/utils/fileValidation.js
@@ -9,15 +9,23 @@ export const SUPPORTED_UPLOAD_MESSAGE = 'Please select a PDF or image file.';
 export const MIXED_UPLOAD_WARNING = 'Some files were skipped. Upload PDFs or image files only.';
 
 export function classifyFileKind(file) {
-  if (!file) {
+  if (!file || typeof file.name !== 'string') {
     return null;
   }
 
-  if (file.type === 'application/pdf') {
+  const lastDotIndex = file.name.lastIndexOf('.');
+  if (lastDotIndex === -1 || lastDotIndex === 0) {
+    return null; // No extension or hidden file without extension
+  }
+
+  const extension = file.name.substring(lastDotIndex + 1).toLowerCase();
+
+  if (file.type === 'application/pdf' && extension === 'pdf') {
     return 'pdf';
   }
 
-  if (typeof file.type === 'string' && file.type.startsWith('image/')) {
+  const allowedImageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'bmp', 'svg'];
+  if (typeof file.type === 'string' && file.type.startsWith('image/') && allowedImageExtensions.includes(extension)) {
     return 'image';
   }
 

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -78,10 +78,15 @@ test.describe('Utils', () => {
   });
 
   test('classifyFileKind', () => {
-    expect(classifyFileKind({ type: 'application/pdf' })).toBe('pdf');
-    expect(classifyFileKind({ type: 'image/png' })).toBe('image');
-    expect(classifyFileKind({ type: 'image/jpeg' })).toBe('image');
-    expect(classifyFileKind({ type: 'text/plain' })).toBeNull();
+    expect(classifyFileKind({ type: 'application/pdf', name: 'document.pdf' })).toBe('pdf');
+    expect(classifyFileKind({ type: 'image/png', name: 'image.png' })).toBe('image');
+    expect(classifyFileKind({ type: 'image/jpeg', name: 'photo.jpeg' })).toBe('image');
+    expect(classifyFileKind({ type: 'text/plain', name: 'notes.txt' })).toBeNull();
+    // New security test cases
+    expect(classifyFileKind({ type: 'application/pdf', name: 'malicious.exe' })).toBeNull();
+    expect(classifyFileKind({ type: 'image/png', name: 'script.js' })).toBeNull();
+    expect(classifyFileKind({ type: 'application/pdf' })).toBeNull(); // Missing name
+    expect(classifyFileKind({ type: 'image/jpeg', name: 'noextension' })).toBeNull();
   });
 
   test('getFileTypeLabel', () => {
@@ -91,7 +96,7 @@ test.describe('Utils', () => {
   });
 
   test('validateUploadFile: valid PDF', () => {
-    expect(validateUploadFile({ type: 'application/pdf', size: 1024 })).toEqual({
+    expect(validateUploadFile({ type: 'application/pdf', size: 1024, name: 'valid.pdf' })).toEqual({
       valid: true,
       errors: [],
       kind: 'pdf'
@@ -99,7 +104,7 @@ test.describe('Utils', () => {
   });
 
   test('validateUploadFile: valid image', () => {
-    expect(validateUploadFile({ type: 'image/png', size: 2048 })).toEqual({
+    expect(validateUploadFile({ type: 'image/png', size: 2048, name: 'valid.png' })).toEqual({
       valid: true,
       errors: [],
       kind: 'image'
@@ -107,10 +112,15 @@ test.describe('Utils', () => {
   });
 
   test('validateUploadFile: unsupported file type', () => {
-    const invalid = validateUploadFile({ type: 'text/plain', size: 12 });
+    const invalid = validateUploadFile({ type: 'text/plain', size: 12, name: 'test.txt' });
     expect(invalid.valid).toBe(false);
     expect(invalid.kind).toBeNull();
     expect(invalid.errors).toContain('Please select a PDF or image file.');
+
+    // Test spoofed mime type
+    const spoofed = validateUploadFile({ type: 'application/pdf', size: 1024, name: 'exploit.html' });
+    expect(spoofed.valid).toBe(false);
+    expect(spoofed.kind).toBeNull();
   });
 
   test('validateUploadFile: null file', () => {


### PR DESCRIPTION
🎯 **What:** Added strict file extension validation based on file name alongside the existing MIME type checks.
⚠️ **Risk:** Client-side file.type is trivially spoofable, allowing unsupported or potentially malicious file types (like scripts or executables) to bypass validation by masquerading as images or PDFs.
🛡️ **Solution:** Implemented logic to extract the file extension from file.name and validate it against an explicit allowlist (pdf, jpg, jpeg, png, webp, gif, bmp, svg) while retaining the original MIME checks.

---
*PR created automatically by Jules for task [2909749185502752261](https://jules.google.com/task/2909749185502752261) started by @guitarbeat*