### PR TITLE
🧪 Add tests for partitionSupportedFiles

### DIFF
--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,7 @@
+🎯 **What:** Added comprehensive unit tests for the `partitionSupportedFiles` function in `src/utils/fileValidation.js` which was previously untested.
+📊 **Coverage:** The new tests cover:
+  - Empty array input
+  - Array containing only supported files (PDF and PNG)
+  - Array containing only unsupported or malformed file entries (text, untyped files, `null`, and `undefined`)
+  - Array containing a mix of supported and unsupported files
+✨ **Result:** Improved test coverage for file upload validation logic, ensuring that the function correctly separates file arrays into `acceptedFiles` and `rejectedFiles` objects and preventing future regressions in this pure function.

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -3,7 +3,8 @@ import { clampNumber, formatFileSize, isNumber, debounce, parseBoundedInteger } 
 import {
   classifyFileKind,
   getFileTypeLabel,
-  validateUploadFile
+  validateUploadFile,
+  partitionSupportedFiles
 } from '../../src/utils/fileValidation.js';
 
 test.describe('Utils', () => {
@@ -83,5 +84,29 @@ test.describe('Utils', () => {
     expect(invalid.valid).toBe(false);
     expect(invalid.kind).toBeNull();
     expect(invalid.errors).toContain('Please select a PDF or image file.');
+  });
+
+  test('partitionSupportedFiles', () => {
+    expect(partitionSupportedFiles([])).toEqual({ acceptedFiles: [], rejectedFiles: [] });
+
+    const pdfFile = { type: 'application/pdf', name: 'doc.pdf' };
+    const imgFile = { type: 'image/png', name: 'pic.png' };
+    const textFile = { type: 'text/plain', name: 'notes.txt' };
+    const noTypeFile = { name: 'unknown' };
+
+    expect(partitionSupportedFiles([pdfFile, imgFile])).toEqual({
+      acceptedFiles: [pdfFile, imgFile],
+      rejectedFiles: []
+    });
+
+    expect(partitionSupportedFiles([textFile, noTypeFile, null, undefined])).toEqual({
+      acceptedFiles: [],
+      rejectedFiles: [textFile, noTypeFile, null, undefined]
+    });
+
+    expect(partitionSupportedFiles([pdfFile, textFile, imgFile, noTypeFile])).toEqual({
+      acceptedFiles: [pdfFile, imgFile],
+      rejectedFiles: [textFile, noTypeFile]
+    });
   });
 });


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the `partitionSupportedFiles` function in `src/utils/fileValidation.js` which was previously untested.
📊 **Coverage:** The new tests cover:
  - Empty array input
  - Array containing only supported files (PDF and PNG)
  - Array containing only unsupported or malformed file entries (text, untyped files, `null`, and `undefined`)
  - Array containing a mix of supported and unsupported files
✨ **Result:** Improved test coverage for file upload validation logic, ensuring that the function correctly separates file arrays into `acceptedFiles` and `rejectedFiles` objects and preventing future regressions in this pure function.

---
*PR created automatically by Jules for task [18031563924211316244](https://jules.google.com/task/18031563924211316244) started by @guitarbeat*