### PR TITLE
🧹 [Extract thumbnail generation logic for better readability]

### DIFF
--- a/src/components/UI/LayoutRenderer.js
+++ b/src/components/UI/LayoutRenderer.js
@@ -219,10 +219,10 @@ export class LayoutRenderer {
     });
 
     const flipBtn = toolbar.querySelector('.flip-btn');
-    if (flipBtn) flipBtn.onclick = (e) => { e.stopPropagation(); handlers.onFlip(pageIndex); };
+    if (flipBtn) { flipBtn.onclick = (e) => { e.stopPropagation(); handlers.onFlip(pageIndex); }; }
 
     const cropBtn = toolbar.querySelector('.crop-btn');
-    if (cropBtn) cropBtn.onclick = (e) => { e.stopPropagation(); handlers.onCrop(pageIndex); };
+    if (cropBtn) { cropBtn.onclick = (e) => { e.stopPropagation(); handlers.onCrop(pageIndex); }; }
 
     return cell;
   }

--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -5,44 +5,13 @@ import {
   PAPER_SIZES,
   ZINE_TEMPLATES
 } from '../../utils/config.js';
-import { debounce, formatFileSize, parseBoundedInteger } from '../../utils/helpers.js';
-import {
-  MAX_UPLOAD_FILES,
-  MIXED_UPLOAD_WARNING,
-  SUPPORTED_UPLOAD_MESSAGE,
-  UNSUPPORTED_UPLOAD_TITLE,
-  getFileTypeLabel,
-  partitionSupportedFiles
-} from '../../utils/fileValidation.js';
-import { toast } from '../Toast.js';
+import { debounce, parseBoundedInteger } from '../../utils/helpers.js';
 
 import { ModalManager } from './ModalManager.js';
 import { DragAndDropHandler } from './DragAndDropHandler.js';
 import { LayoutRenderer } from './LayoutRenderer.js';
 import { PAGE_CELL_TEMPLATE } from './Templates.js';
 
-const FOLD_STAGES = [
-  {
-    threshold: 2.75,
-    label: 'Booklet',
-    helper: 'Collapse the four sections together so your cover page is outermost. No stapling needed — the single cut holds everything together.'
-  },
-  {
-    threshold: 1.75,
-    label: 'Diamond Open',
-    helper: 'Push both short ends inward — the center slit opens into a diamond or cross shape. Keep pushing until all four page sections meet.'
-  },
-  {
-    threshold: 0.75,
-    label: 'Folded Strip',
-    helper: 'Fold in half along the long axis, pages facing out. Cut through both layers along the center crease, only between the quarter-fold marks.'
-  },
-  {
-    threshold: -Infinity,
-    label: 'Flat',
-    helper: 'Print the layout, then crease the sheet in half both ways and open flat. Make two more creases to divide the long direction into quarters.'
-  }
-];
 
 const DEFAULT_GRID_ROWS = 2;
 const DEFAULT_GRID_COLS = 4;
@@ -150,7 +119,7 @@ export class UIManager {
   }
 
   handleIncomingFiles(files) {
-    if (!files?.length) return;
+    if (!files?.length) { return; }
     files.forEach((file) => this.emitter.emit('fileSelected', file));
   }
 
@@ -213,8 +182,8 @@ export class UIManager {
   normalizeGridInputs() {
     const rows = parseBoundedInteger(this.elements.gridRows?.value, { min: GRID_DIMENSION_MIN, max: GRID_DIMENSION_MAX, fallback: DEFAULT_GRID_ROWS });
     const cols = parseBoundedInteger(this.elements.gridCols?.value, { min: GRID_DIMENSION_MIN, max: GRID_DIMENSION_MAX, fallback: DEFAULT_GRID_COLS });
-    if (this.elements.gridRows) this.elements.gridRows.value = rows;
-    if (this.elements.gridCols) this.elements.gridCols.value = cols;
+    if (this.elements.gridRows) {this.elements.gridRows.value = rows;}
+    if (this.elements.gridCols) {this.elements.gridCols.value = cols;}
     return { rows, cols };
   }
 
@@ -349,7 +318,7 @@ export class UIManager {
     this.elements.gridRows?.closest('.workspace-config-split')?.querySelectorAll('.stepper-btn').forEach((btn) => {
       btn.addEventListener('click', () => {
         const target = document.getElementById(btn.dataset.target);
-        if (!target) return;
+        if (!target) {return;}
         const min = parseInt(target.min, 10) || 1;
         const max = parseInt(target.max, 10) || 10;
         const delta = parseInt(btn.dataset.delta, 10);

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -4,7 +4,7 @@ import { StateStore } from './StateStore.js';
 import { UndoManager } from './UndoManager.js';
 import { ExportService } from '../services/ExportService.js';
 import { toast } from '../components/Toast.js';
-import referenceImageUrl from '../assets/reference-back-side.jpg';
+
 import { GRID_DIMENSION_MAX, GRID_DIMENSION_MIN } from '../utils/config.js';
 import { parseBoundedInteger } from '../utils/helpers.js';
 import { classifyFileKind, SUPPORTED_UPLOAD_MESSAGE, UNSUPPORTED_UPLOAD_TITLE } from '../utils/fileValidation.js';
@@ -233,6 +233,50 @@ export class AppController {
     toast.success('Import Complete', status);
   }
 
+  async _generateThumbnails(numPages, thumbnails) {
+    // ⚡ Bolt: Sliding window worker pool for faster thumbnail generation
+    // This maintains a constant stream of processing instead of waiting for batched promises,
+    // avoiding UI stuttering and utilizing resources more evenly.
+    const CONCURRENCY_LIMIT = 4;
+    const activePromises = new Set();
+    let completedCount = 0;
+
+    const processPage = async (pageNumber) => {
+      const canvas = await this.pdfProcessor.renderPageThumbnail(pageNumber);
+      const thumbnailUrl = await this.pdfProcessor.canvasToBlob(canvas);
+      thumbnails.push({ pageNumber, thumbnailUrl });
+
+      completedCount++;
+      const percent = Math.round((completedCount / numPages) * 100);
+      this.ui.modal.setProgressCopy('Preparing page picker...', `${percent}%`);
+      this.ui.modal.updateProgress(percent);
+    };
+
+    try {
+      for (let pageNumber = 1; pageNumber <= numPages; pageNumber++) {
+        // Intentional forward reference: `trackedPromise` is captured by the `.finally()` closure
+        // so that the Set removes the correct (finally-wrapped) promise upon settlement.
+        const trackedPromise = processPage(pageNumber).finally(() => activePromises.delete(trackedPromise));
+        activePromises.add(trackedPromise);
+
+        if (activePromises.size >= CONCURRENCY_LIMIT) {
+          await Promise.race(activePromises);
+        }
+      }
+
+      await Promise.all(activePromises);
+
+      // Ensure thumbnails are sorted by pageNumber since they resolve out of order
+      thumbnails.sort((a, b) => a.pageNumber - b.pageNumber);
+    } catch (error) {
+      await Promise.allSettled(Array.from(activePromises));
+      thumbnails.forEach(({ thumbnailUrl }) => {
+        this.pdfProcessor.revokeBlobUrl(thumbnailUrl);
+      });
+      throw error;
+    }
+  }
+
   async getSelectedPagesForImport(fileName, numPages) {
     const selectionLimit = Math.max(1, this.state.gridSize.rows * this.state.gridSize.cols);
 
@@ -245,47 +289,7 @@ export class AppController {
     this.ui.modal.updateProgress(0);
 
     try {
-      // ⚡ Bolt: Sliding window worker pool for faster thumbnail generation
-      // This maintains a constant stream of processing instead of waiting for batched promises,
-      // avoiding UI stuttering and utilizing resources more evenly.
-      const CONCURRENCY_LIMIT = 4;
-      const activePromises = new Set();
-      let completedCount = 0;
-
-      const processPage = async (pageNumber) => {
-        const canvas = await this.pdfProcessor.renderPageThumbnail(pageNumber);
-        const thumbnailUrl = await this.pdfProcessor.canvasToBlob(canvas);
-        thumbnails.push({ pageNumber, thumbnailUrl });
-
-        completedCount++;
-        const percent = Math.round((completedCount / numPages) * 100);
-        this.ui.modal.setProgressCopy('Preparing page picker...', `${percent}%`);
-        this.ui.modal.updateProgress(percent);
-      };
-
-      try {
-        for (let pageNumber = 1; pageNumber <= numPages; pageNumber++) {
-          // Intentional forward reference: `trackedPromise` is captured by the `.finally()` closure
-          // so that the Set removes the correct (finally-wrapped) promise upon settlement.
-          const trackedPromise = processPage(pageNumber).finally(() => activePromises.delete(trackedPromise));
-          activePromises.add(trackedPromise);
-
-          if (activePromises.size >= CONCURRENCY_LIMIT) {
-            await Promise.race(activePromises);
-          }
-        }
-
-        await Promise.all(activePromises);
-
-        // Ensure thumbnails are sorted by pageNumber since they resolve out of order
-        thumbnails.sort((a, b) => a.pageNumber - b.pageNumber);
-      } catch (error) {
-        await Promise.allSettled(Array.from(activePromises));
-        thumbnails.forEach(({ thumbnailUrl }) => {
-          this.pdfProcessor.revokeBlobUrl(thumbnailUrl);
-        });
-        throw error;
-      }
+      await this._generateThumbnails(numPages, thumbnails);
     } finally {
       this.ui.modal.showProgress(false);
     }
@@ -671,7 +675,7 @@ export class AppController {
           const Zine3DViewer = await this.getZine3DViewerClass();
           try {
             this.viewer3d = new Zine3DViewer(container);
-          } catch (viewerError) {
+          } catch {
             const fallback = container.querySelector('.zine-3d-fallback-canvas');
             if (fallback) {
               fallback.remove();

--- a/src/services/ExportService.js
+++ b/src/services/ExportService.js
@@ -67,7 +67,7 @@ export class ExportService {
 
         const pageIndex = (sheetIndex * slotsPerSheet) + (pageNum - 1);
         const url = this.state.allPageImages[pageIndex];
-        if (!url) continue;
+        if (!url) {continue;}
 
         const isFlipped = !!this.state.pageFlips[pageIndex];
         const isZoomed = !!this.state.pageZooms[pageIndex];


### PR DESCRIPTION
🎯 **What:** Extracted the complex sliding window worker pool for thumbnail generation from `getSelectedPagesForImport` into a new `_generateThumbnails` async method. Cleaned up unused variables and imports in AppController.js.
💡 **Why:** `getSelectedPagesForImport` was too long and handled multiple disparate concerns (UI setup, thumbnail generation, modal launching). Moving the thumbnail pool out isolates the logic and improves readability.
✅ **Verification:** Ran test suite, verified safe extraction, ran linting tests successfully.
✨ **Result:** Improved separation of concerns, cleaner `getSelectedPagesForImport` function.

---
*PR created automatically by Jules for task [779468967476509241](https://jules.google.com/task/779468967476509241) started by @guitarbeat*