### PR TITLE
🧹 [flatten deeply nested conditionals in handleView3d and fix linting errors]

### DIFF
--- a/src/components/UI/LayoutRenderer.js
+++ b/src/components/UI/LayoutRenderer.js
@@ -219,10 +219,10 @@ export class LayoutRenderer {
     });
 
     const flipBtn = toolbar.querySelector('.flip-btn');
-    if (flipBtn) flipBtn.onclick = (e) => { e.stopPropagation(); handlers.onFlip(pageIndex); };
+    if (flipBtn) { flipBtn.onclick = (e) => { e.stopPropagation(); handlers.onFlip(pageIndex); }; }
 
     const cropBtn = toolbar.querySelector('.crop-btn');
-    if (cropBtn) cropBtn.onclick = (e) => { e.stopPropagation(); handlers.onCrop(pageIndex); };
+    if (cropBtn) { cropBtn.onclick = (e) => { e.stopPropagation(); handlers.onCrop(pageIndex); }; }
 
     return cell;
   }

--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -5,44 +5,12 @@ import {
   PAPER_SIZES,
   ZINE_TEMPLATES
 } from '../../utils/config.js';
-import { debounce, formatFileSize, parseBoundedInteger } from '../../utils/helpers.js';
-import {
-  MAX_UPLOAD_FILES,
-  MIXED_UPLOAD_WARNING,
-  SUPPORTED_UPLOAD_MESSAGE,
-  UNSUPPORTED_UPLOAD_TITLE,
-  getFileTypeLabel,
-  partitionSupportedFiles
-} from '../../utils/fileValidation.js';
-import { toast } from '../Toast.js';
+import { debounce, parseBoundedInteger } from '../../utils/helpers.js';
 
 import { ModalManager } from './ModalManager.js';
 import { DragAndDropHandler } from './DragAndDropHandler.js';
 import { LayoutRenderer } from './LayoutRenderer.js';
 import { PAGE_CELL_TEMPLATE } from './Templates.js';
-
-const FOLD_STAGES = [
-  {
-    threshold: 2.75,
-    label: 'Booklet',
-    helper: 'Collapse the four sections together so your cover page is outermost. No stapling needed — the single cut holds everything together.'
-  },
-  {
-    threshold: 1.75,
-    label: 'Diamond Open',
-    helper: 'Push both short ends inward — the center slit opens into a diamond or cross shape. Keep pushing until all four page sections meet.'
-  },
-  {
-    threshold: 0.75,
-    label: 'Folded Strip',
-    helper: 'Fold in half along the long axis, pages facing out. Cut through both layers along the center crease, only between the quarter-fold marks.'
-  },
-  {
-    threshold: -Infinity,
-    label: 'Flat',
-    helper: 'Print the layout, then crease the sheet in half both ways and open flat. Make two more creases to divide the long direction into quarters.'
-  }
-];
 
 const DEFAULT_GRID_ROWS = 2;
 const DEFAULT_GRID_COLS = 4;
@@ -150,7 +118,7 @@ export class UIManager {
   }
 
   handleIncomingFiles(files) {
-    if (!files?.length) return;
+    if (!files?.length) {return;}
     files.forEach((file) => this.emitter.emit('fileSelected', file));
   }
 
@@ -213,8 +181,8 @@ export class UIManager {
   normalizeGridInputs() {
     const rows = parseBoundedInteger(this.elements.gridRows?.value, { min: GRID_DIMENSION_MIN, max: GRID_DIMENSION_MAX, fallback: DEFAULT_GRID_ROWS });
     const cols = parseBoundedInteger(this.elements.gridCols?.value, { min: GRID_DIMENSION_MIN, max: GRID_DIMENSION_MAX, fallback: DEFAULT_GRID_COLS });
-    if (this.elements.gridRows) this.elements.gridRows.value = rows;
-    if (this.elements.gridCols) this.elements.gridCols.value = cols;
+    if (this.elements.gridRows) {this.elements.gridRows.value = rows;}
+    if (this.elements.gridCols) {this.elements.gridCols.value = cols;}
     return { rows, cols };
   }
 
@@ -349,7 +317,7 @@ export class UIManager {
     this.elements.gridRows?.closest('.workspace-config-split')?.querySelectorAll('.stepper-btn').forEach((btn) => {
       btn.addEventListener('click', () => {
         const target = document.getElementById(btn.dataset.target);
-        if (!target) return;
+        if (!target) {return;}
         const min = parseInt(target.min, 10) || 1;
         const max = parseInt(target.max, 10) || 10;
         const delta = parseInt(btn.dataset.delta, 10);

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -4,7 +4,6 @@ import { StateStore } from './StateStore.js';
 import { UndoManager } from './UndoManager.js';
 import { ExportService } from '../services/ExportService.js';
 import { toast } from '../components/Toast.js';
-import referenceImageUrl from '../assets/reference-back-side.jpg';
 import { GRID_DIMENSION_MAX, GRID_DIMENSION_MIN } from '../utils/config.js';
 import { parseBoundedInteger } from '../utils/helpers.js';
 import { classifyFileKind, SUPPORTED_UPLOAD_MESSAGE, UNSUPPORTED_UPLOAD_TITLE } from '../utils/fileValidation.js';
@@ -667,20 +666,22 @@ export class AppController {
 
       if (!this.viewer3d) {
         const container = this.ui.elements.zine3dContainer;
-        if (container) {
-          const Zine3DViewer = await this.getZine3DViewerClass();
-          try {
-            this.viewer3d = new Zine3DViewer(container);
-          } catch (viewerError) {
-            const fallback = container.querySelector('.zine-3d-fallback-canvas');
-            if (fallback) {
-              fallback.remove();
-            }
-            this.viewer3d = null;
-            this.ui.toggle3DModal(false);
-            toast.error('3D Preview Failed', 'Unable to initialize the fold preview.');
-            return;
+        if (!container) {
+          return;
+        }
+
+        const Zine3DViewer = await this.getZine3DViewerClass();
+        try {
+          this.viewer3d = new Zine3DViewer(container);
+        } catch {
+          const fallback = container.querySelector('.zine-3d-fallback-canvas');
+          if (fallback) {
+            fallback.remove();
           }
+          this.viewer3d = null;
+          this.ui.toggle3DModal(false);
+          toast.error('3D Preview Failed', 'Unable to initialize the fold preview.');
+          return;
         }
       }
 

--- a/src/services/ExportService.js
+++ b/src/services/ExportService.js
@@ -67,7 +67,7 @@ export class ExportService {
 
         const pageIndex = (sheetIndex * slotsPerSheet) + (pageNum - 1);
         const url = this.state.allPageImages[pageIndex];
-        if (!url) continue;
+        if (!url) { continue; }
 
         const isFlipped = !!this.state.pageFlips[pageIndex];
         const isZoomed = !!this.state.pageZooms[pageIndex];


### PR DESCRIPTION
🎯 **What:**
- Refactored `handleView3d` in `AppController.js` to flatten deeply nested conditionals by using an early return.
- Removed unused `referenceImageUrl` from `AppController.js`.
- Removed unused imports and variable (`FOLD_STAGES`) in `UIManager.js` that were causing lint errors.

💡 **Why:** 
Deeply nested conditionals reduce readability and make functions harder to maintain. By flattening the structure using early returns, we make the control flow linear and easier to understand. Fixing lint errors resolves codebase health issues.

✅ **Verification:** 
- `pnpm lint` now succeeds without any errors.
- The test suite (`pnpm test`) was executed. Existing test suite failures were observed but none relate to the modifications made.

✨ **Result:**
Improved the maintainability and readability of `handleView3d` and removed dead code that triggered lint warnings, thereby improving the overall health of the codebase.

---
*PR created automatically by Jules for task [6399742964843531088](https://jules.google.com/task/6399742964843531088) started by @guitarbeat*

## Summary by Sourcery

Refactor 3D viewer initialization and clean up unused UI code to improve readability and satisfy linting rules.

Enhancements:
- Simplify 3D viewer setup in AppController by flattening control flow and using early returns when the container is unavailable or initialization fails.

Chores:
- Remove unused imports, constants, and variables in UIManager to eliminate lint warnings and dead code.
- Apply minor stylistic updates to guard clauses and input normalization in UIManager for consistency with linting preferences.