### PR TITLE
🧹 [code health] Update confusing test comments

### DIFF
--- a/tests/security/strict_pdf_validation.spec.js
+++ b/tests/security/strict_pdf_validation.spec.js
@@ -21,8 +21,8 @@ test('Should reject polyglot files (PDF signature not at offset 0)', async ({ pa
   });
 
   // Check for the specific error message in the toast
-  // If the vulnerability is fixed, this toast should appear.
-  // If the vulnerability exists, the app accepts it (and maybe fails later with a parsing error),
+  // If the app correctly validates the signature, this toast should appear.
+  // If the app fails to validate the signature, the app accepts it (and maybe fails later with a parsing error),
   // so we won't see "Invalid file signature".
   const toastMessage = page.locator('#toast-container');
   await expect(toastMessage).toContainText('Invalid file signature', { timeout: 5000 });


### PR DESCRIPTION
What:
Replaced confusing comment text in `tests/security/strict_pdf_validation.spec.js` ('If the vulnerability is fixed' and 'If the vulnerability exists') with clearer descriptions of the validation behavior ('If the app correctly validates the signature' and 'If the app fails to validate the signature').

Why:
These comments were incorrectly being flagged by vulnerability/TODO scanners as actionable items. The new text accurately describes the test behavior without triggering scanners.

Verification:
Ran `pnpm exec playwright test tests/security/strict_pdf_validation.spec.js` locally, which passed successfully. Verified that no functional code was modified.

Result:
Test files now contain accurate comments that don't trigger false positives.

---
*PR created automatically by Jules for task [9215673556478387096](https://jules.google.com/task/9215673556478387096) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Update comments in strict PDF validation test to describe signature validation behavior instead of using vulnerability-focused wording.