### PR TITLE
fix: restore booklet preview styles and reading-order UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@
                         <div class="simulation-panel-top">
                             <div>
                                 <p class="simulation-panel-kicker">Booklet</p>
-                                <p class="simulation-panel-title">Check the reading order beside the fold.</p>
+                                <p class="simulation-panel-title">Use Prev / Next to step through each spread in reading order.</p>
                             </div>
                             <span id="booklet-status" class="simulation-status-chip">Loading</span>
                         </div>

--- a/src/components/BookletPreview.js
+++ b/src/components/BookletPreview.js
@@ -38,11 +38,11 @@ export class BookletPreview {
             <div class="booklet-turn-layer" aria-hidden="true">
               <div class="booklet-turn-card">
                 <div class="booklet-face booklet-face-front">
-                  <img class="booklet-page-media" alt="Turning page front">
+                  <img class="booklet-page-media" alt="">
                   <span class="booklet-page-placeholder"></span>
                 </div>
                 <div class="booklet-face booklet-face-back">
-                  <img class="booklet-page-media" alt="Turning page back">
+                  <img class="booklet-page-media" alt="">
                   <span class="booklet-page-placeholder"></span>
                 </div>
               </div>
@@ -87,9 +87,22 @@ export class BookletPreview {
     this.states = buildMiniZineBookletStates(this.slotPages);
     this.spreadIndex = 0;
     this.isAnimating = false;
-    this.turnLayer?.classList.remove('is-visible', 'is-active', 'is-next', 'is-prev');
+    this.hideTurnLayer();
     this.updateStaticSpread();
     this.updateControls();
+  }
+
+  hideTurnLayer() {
+    this.turnLayer?.classList.remove('is-visible', 'is-active', 'is-next', 'is-prev');
+    this.turnLayer?.setAttribute('aria-hidden', 'true');
+    this.setPageFace(this.turnFront, null);
+    this.setPageFace(this.turnBack, null);
+  }
+
+  showTurnLayer(direction) {
+    this.turnLayer?.classList.remove('is-prev', 'is-next');
+    this.turnLayer?.classList.add(direction > 0 ? 'is-next' : 'is-prev', 'is-visible');
+    this.turnLayer?.setAttribute('aria-hidden', 'false');
   }
 
   getCurrentState() {
@@ -214,18 +227,15 @@ export class BookletPreview {
       this.setPageFace(this.rightPage, nextState.right);
       this.setPageFace(this.turnFront, currentState.right);
       this.setPageFace(this.turnBack, nextState.left);
-      this.turnLayer.classList.remove('is-prev');
-      this.turnLayer.classList.add('is-next');
+      this.showTurnLayer(direction);
     } else {
       this.setPageFace(this.leftPage, nextState.left);
       this.setPageFace(this.rightPage, currentState.right);
       this.setPageFace(this.turnFront, currentState.left);
       this.setPageFace(this.turnBack, nextState.right);
-      this.turnLayer.classList.remove('is-next');
-      this.turnLayer.classList.add('is-prev');
+      this.showTurnLayer(direction);
     }
 
-    this.turnLayer.classList.add('is-visible');
     this.updateControls();
 
     requestAnimationFrame(() => {
@@ -243,7 +253,7 @@ export class BookletPreview {
     this.spreadIndex = this.pendingSpreadIndex;
     this.pendingSpreadIndex = null;
     this.isAnimating = false;
-    this.turnLayer.classList.remove('is-visible', 'is-active', 'is-next', 'is-prev');
+    this.hideTurnLayer();
     this.updateStaticSpread();
     this.updateControls();
   }

--- a/src/styles/simulation.css
+++ b/src/styles/simulation.css
@@ -197,8 +197,88 @@
   backface-visibility: hidden;
 }
 
-.booklet-page-left, .booklet-face-front { left: 0; }
-.booklet-page-right, .booklet-face-back { right: 0; }
+.booklet-page-left,
+.booklet-face-front {
+  left: 0;
+}
+
+.booklet-page-right,
+.booklet-face-back {
+  right: 0;
+}
+
+.booklet-page-left {
+  border-right-width: 1px;
+  transform: rotateY(8deg) translateZ(1px);
+  cursor: w-resize;
+}
+
+.booklet-page-right {
+  border-left-width: 1px;
+  transform: rotateY(-8deg) translateZ(1px);
+  cursor: e-resize;
+}
+
+.booklet-page:hover {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.14);
+}
+
+.booklet-spread.is-single-page .booklet-spine {
+  opacity: 0;
+}
+
+.booklet-spread.is-single-right .booklet-page-left,
+.booklet-spread.is-single-left .booklet-page-right {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.booklet-spread.is-single-right .booklet-page-right,
+.booklet-spread.is-single-left .booklet-page-left {
+  width: 100%;
+  left: 0;
+  right: auto;
+  border-width: 1px;
+}
+
+.booklet-spread.is-single-right .booklet-page-right {
+  transform: rotateY(-4deg) translateZ(1px);
+}
+
+.booklet-spread.is-single-left .booklet-page-left {
+  transform: rotateY(4deg) translateZ(1px);
+}
+
+.booklet-page.is-empty,
+.booklet-face.is-empty {
+  background:
+    linear-gradient(135deg, rgba(0, 0, 0, 0.04), transparent 55%),
+    var(--surface-bg);
+}
+
+.booklet-page-media {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: none;
+  background: var(--surface-bg);
+}
+
+.booklet-page-media.is-visible {
+  display: block;
+}
+
+.booklet-page-placeholder {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 0.4rem 0.5rem;
+  text-align: center;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-ink);
+}
 
 .booklet-spine {
   position: absolute;
@@ -210,6 +290,66 @@
   background: linear-gradient(180deg, rgba(0,0,0,0.2), rgba(255,255,255,0.1) 35%, rgba(0,0,0,0.2));
   border-radius: 999px;
   opacity: 0.25;
+}
+
+.booklet-turn-layer {
+  position: absolute;
+  top: 0;
+  width: 50%;
+  height: 100%;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transform-style: preserve-3d;
+  z-index: 4;
+}
+
+.booklet-turn-layer.is-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.booklet-turn-layer.is-next {
+  right: 0;
+}
+
+.booklet-turn-layer.is-prev {
+  left: 0;
+}
+
+.booklet-turn-card {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform 0.55s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.booklet-turn-layer.is-next .booklet-turn-card {
+  transform-origin: left center;
+}
+
+.booklet-turn-layer.is-prev .booklet-turn-card {
+  transform-origin: right center;
+}
+
+.booklet-turn-layer.is-next.is-active .booklet-turn-card {
+  transform: rotateY(-180deg);
+}
+
+.booklet-turn-layer.is-prev.is-active .booklet-turn-card {
+  transform: rotateY(180deg);
+}
+
+.booklet-face-front,
+.booklet-face-back {
+  width: 100%;
+  left: 0;
+  right: auto;
+}
+
+.booklet-face-back {
+  transform: rotateY(180deg);
 }
 
 .simulation-fold-guide {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The booklet preview in the fold simulation modal showed broken "Turning page front/back" placeholders on top of the cover instead of the actual page content.

## Root cause

When styles were split into `simulation.css`, most booklet-specific rules were dropped. Without them:

- The page-turn animation layer stayed visible (`opacity: 1`) even when idle
- Empty `<img>` elements rendered as broken image icons
- `.booklet-page-media` was always shown (no `display: none` until `.is-visible`)
- Single-page spread layout (cover/back) did not apply

## Fix

- Restore booklet preview CSS in `simulation.css`: turn-layer visibility, page media display, single-spread layout, flip animation, placeholders
- Hide and clear the turn layer when not animating in `BookletPreview.js`
- Clarify booklet panel copy: "Use Prev / Next to step through each spread in reading order."

## Testing

- Unit tests for mini zine layout and preview helpers pass
- E2e booklet assertions (`#booklet-status` Cover, `.is-single-right`) pass in the 3D preview flow
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccd4d800-0673-46ac-a73b-803d7572504f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccd4d800-0673-46ac-a73b-803d7572504f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

