### PR TITLE
Overhaul fold preview and remove print button

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,13 +186,6 @@
                         <span class="material-symbols-outlined text-[18px]" aria-hidden="true">download</span>
                         <span id="exportPdfBtnLabel">Export PDF</span>
                     </button>
-                    <button id="printBtn"
-                        class="action-button workspace-action-button flex items-center justify-center gap-2"
-                        style="background-color: var(--primary-vibrant); color: white; border-color: rgba(0,0,0,0.1) !important;"
-                        title="Print Zine">
-                        <span class="material-symbols-outlined text-[18px]" aria-hidden="true">print</span>
-                        <span id="printBtnLabel">Print</span>
-                    </button>
                     <button id="view3dBtn"
                         class="action-button workspace-action-button workspace-action-button-secondary flex items-center justify-center gap-2"
                         title="3D Preview">
@@ -283,27 +276,27 @@
                         </div>
 
                         <p id="fold-helper" class="simulation-helper">
-                            Print the layout, crease the sheet in half both ways and open flat, then fold and make one short cut through the center before collapsing into a booklet.
+                            Export the layout, crease the sheet in half both ways and open flat, then fold and make one short cut through the center before collapsing into a booklet.
                         </p>
 
-                        <div class="simulation-step-grid">
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="0">
-                                1. Flat sheet
+                        <div class="simulation-step-grid" aria-label="Fold simulation checkpoints">
+                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="0" data-step-index="1">
+                                1. Layout
                             </button>
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="0.5">
-                                2. Crease halves
+                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="0.5" data-step-index="2">
+                                2. Crease
                             </button>
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="1">
-                                3. Fold to strip
+                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="1" data-step-index="3">
+                                3. Strip
                             </button>
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="1.5">
-                                4. Make the cut
+                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="1.5" data-step-index="4">
+                                4. Cut
                             </button>
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="2">
-                                5. Diamond opens
+                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="2" data-step-index="5">
+                                5. Diamond
                             </button>
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="3">
-                                6. Press to booklet
+                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="3" data-step-index="6">
+                                6. Booklet
                             </button>
                         </div>
                     </section>

--- a/src/components/BookletPreview.js
+++ b/src/components/BookletPreview.js
@@ -23,27 +23,32 @@ export class BookletPreview {
 
   renderBase() {
     this.container.innerHTML = `
-      <div class="booklet-shell">
+      <div class="booklet-shell" tabindex="0" role="group" aria-label="Booklet spread preview. Use left and right arrow keys to turn pages.">
         <div class="booklet-stage">
+          <div class="booklet-shadow" aria-hidden="true"></div>
           <div class="booklet-spread">
             <div class="booklet-page booklet-page-left" data-side="left">
               <img class="booklet-page-media" alt="Left page preview">
               <span class="booklet-page-placeholder"></span>
+              <span class="booklet-page-label"></span>
             </div>
             <div class="booklet-spine" aria-hidden="true"></div>
             <div class="booklet-page booklet-page-right" data-side="right">
               <img class="booklet-page-media" alt="Right page preview">
               <span class="booklet-page-placeholder"></span>
+              <span class="booklet-page-label"></span>
             </div>
             <div class="booklet-turn-layer" aria-hidden="true">
               <div class="booklet-turn-card">
                 <div class="booklet-face booklet-face-front">
                   <img class="booklet-page-media" alt="">
                   <span class="booklet-page-placeholder"></span>
+                  <span class="booklet-page-label"></span>
                 </div>
                 <div class="booklet-face booklet-face-back">
                   <img class="booklet-page-media" alt="">
                   <span class="booklet-page-placeholder"></span>
+                  <span class="booklet-page-label"></span>
                 </div>
               </div>
             </div>
@@ -59,6 +64,7 @@ export class BookletPreview {
     this.turnCard = this.container.querySelector('.booklet-turn-card');
     this.turnFront = this.container.querySelector('.booklet-face-front');
     this.turnBack = this.container.querySelector('.booklet-face-back');
+    this.shell = this.container.querySelector('.booklet-shell');
   }
 
   bindControls() {
@@ -67,6 +73,15 @@ export class BookletPreview {
     this.turnCard?.addEventListener('transitionend', () => this.finishTurn());
     this.leftPage?.addEventListener('click', () => this.goPrev());
     this.rightPage?.addEventListener('click', () => this.goNext());
+    this.shell?.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        this.goPrev();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        this.goNext();
+      }
+    });
   }
 
   loadPages(imageUrls = []) {
@@ -141,6 +156,7 @@ export class BookletPreview {
 
     const media = element.querySelector('.booklet-page-media');
     const placeholder = element.querySelector('.booklet-page-placeholder');
+    const label = element.querySelector('.booklet-page-label');
     const src = page?.previewUrl || page?.sourceUrl || null;
     const pageLabel = page ? getPageLabel(page.pageNumber, 8) : 'Blank';
 
@@ -160,6 +176,10 @@ export class BookletPreview {
       element.classList.add('is-empty');
     }
 
+    if (label) {
+      label.textContent = pageLabel;
+      label.hidden = !page;
+    }
     element.dataset.pageNumber = page?.pageNumber ? String(page.pageNumber) : '';
     media.alt = `${pageLabel} preview`;
   }

--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -15,6 +15,38 @@ import { PAGE_CELL_TEMPLATE } from './Templates.js';
 
 const DEFAULT_GRID_ROWS = 2;
 const DEFAULT_GRID_COLS = 4;
+const FOLD_STEPS = [
+  {
+    value: 0,
+    status: 'Flat',
+    helper: 'Start with the imposed sheet face up. Red marks the center slit; gray marks the crease grid.'
+  },
+  {
+    value: 0.5,
+    status: 'Creasing',
+    helper: 'Crease the sheet across the short and long axes, then reopen it so every panel has a hinge.'
+  },
+  {
+    value: 1,
+    status: 'Folded Strip',
+    helper: 'Fold the sheet lengthwise into a strip with the page artwork facing outward.'
+  },
+  {
+    value: 1.5,
+    status: 'Center Cut',
+    helper: 'Cut only the center slit, stopping at the quarter folds. The red guide shows the cut span.'
+  },
+  {
+    value: 2,
+    status: 'Diamond Open',
+    helper: 'Push the short ends together so the slit opens into a diamond and the page stacks swing inward.'
+  },
+  {
+    value: 3,
+    status: 'Booklet',
+    helper: 'Press the panels into a booklet stack with the cover outside, then page through the reading preview.'
+  }
+];
 
 export class UIManager {
   constructor() {
@@ -105,9 +137,31 @@ export class UIManager {
   }
 
   setFoldProgressControl(value) {
+    const parsedValue = typeof value === 'number' ? value : parseFloat(value || '0');
+    const progress = Number.isFinite(parsedValue) ? parsedValue : 0;
     if (this.elements.foldSlider) {
-      this.elements.foldSlider.value = value;
+      this.elements.foldSlider.value = progress;
     }
+    this.syncFoldStepUi(progress);
+  }
+
+  syncFoldStepUi(progress) {
+    const currentStep = FOLD_STEPS.reduce((closest, step) => (
+      Math.abs(step.value - progress) < Math.abs(closest.value - progress) ? step : closest
+    ), FOLD_STEPS[0]);
+
+    if (this.elements.foldStatus) {
+      this.elements.foldStatus.textContent = currentStep.status;
+    }
+    if (this.elements.foldHelper) {
+      this.elements.foldHelper.textContent = currentStep.helper;
+    }
+
+    this.elements.foldStepButtons?.forEach((button) => {
+      const isActive = Number(button.dataset.foldValue) === currentStep.value;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', String(isActive));
+    });
   }
 
   toggleMobileRail(show) {
@@ -237,8 +291,6 @@ export class UIManager {
       gridRows: $('#grid-rows'),
       gridCols: $('#grid-cols'),
       gridTotal: $('#grid-total'),
-      printBtn: $('#printBtn'),
-      printBtnLabel: $('#printBtnLabel'),
       exportPdfBtn: $('#exportPdfBtn'),
       exportPdfBtnLabel: $('#exportPdfBtnLabel'),
       view3dBtn: $('#view3dBtn'),
@@ -337,7 +389,6 @@ export class UIManager {
       this._applyPageControlsVisibility(event.target.checked);
     });
 
-    this.elements.printBtn?.addEventListener('click', () => this.emitter.emit('print'));
     this.elements.exportPdfBtn?.addEventListener('click', () => this.emitter.emit('export'));
     this.elements.view3dBtn?.addEventListener('click', () => this.emitter.emit('view3d'));
     this.elements.clearAllBtn?.addEventListener('click', () => this.emitter.emit('clearAll'));
@@ -362,11 +413,27 @@ export class UIManager {
     });
 
     this.elements.foldStepButtons?.forEach((button) => {
+      button.setAttribute('aria-pressed', 'false');
       button.addEventListener('click', () => {
         const value = parseFloat(button.dataset.foldValue || '0');
         this.setFoldProgressControl(value);
         this.emitter.emit('foldProgress', value);
       });
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (!this.isFoldPreviewOpen() || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return;
+      }
+
+      const stepButton = Array.from(this.elements.foldStepButtons || [])
+        .find((button) => button.dataset.stepIndex === event.key);
+      if (!stepButton) {
+        return;
+      }
+
+      event.preventDefault();
+      stepButton.click();
     });
 
     this.dnd.setupEventListeners();
@@ -390,6 +457,12 @@ export class UIManager {
     this.elements.gridCols?.addEventListener('input', debouncedGridChange);
 
     window.addEventListener('resize', () => this.syncResponsiveUI());
+  }
+
+  isFoldPreviewOpen() {
+    return !!this.elements.zine3dModal
+      && !this.elements.zine3dModal.classList.contains('hidden')
+      && this.elements.zine3dModal.style.display !== 'none';
   }
 
   generateLayout(numPages, templateType, paperSettings = {}) {

--- a/src/components/Zine3DViewer.js
+++ b/src/components/Zine3DViewer.js
@@ -11,6 +11,7 @@ export class Zine3DViewer {
     this.stacks = [];
     this.seams = [];
     this.guides = [];
+    this.environmentMeshes = [];
     this.w = 1.0;
     this.h = 1.414; // A-series proportion
     this.panelThickness = 0.002;
@@ -61,6 +62,7 @@ export class Zine3DViewer {
       { type: 'slit', orientation: 'horizontal', x: 0, y: 0, length: this.w * 2 }
     ];
     this.debugFoldState = null;
+    this.currentFoldProgress = 0;
     
     this.initScene();
   }
@@ -75,9 +77,12 @@ export class Zine3DViewer {
     this.camera.position.set(0, 0, 4.6);
 
     try {
-      this.renderer = new THREE.WebGLRenderer({ antialias: true });
+      this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
       this.renderer.setSize(initialWidth, initialHeight);
       this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      this.renderer.domElement.classList.add('zine-3d-canvas');
+      this.renderer.shadowMap.enabled = true;
+      this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       this.container.appendChild(this.renderer.domElement);
     } catch {
       this.initFallbackScene(initialWidth, initialHeight);
@@ -98,6 +103,11 @@ export class Zine3DViewer {
 
     const dirLight = new THREE.DirectionalLight(0xffffff, 1.1);
     dirLight.position.set(2, 6, 5);
+    dirLight.castShadow = true;
+    dirLight.shadow.mapSize.width = 1024;
+    dirLight.shadow.mapSize.height = 1024;
+    dirLight.shadow.camera.near = 0.5;
+    dirLight.shadow.camera.far = 12;
     this.scene.add(dirLight);
     
     const backLight = new THREE.DirectionalLight(0xffffff, 0.45);
@@ -105,6 +115,7 @@ export class Zine3DViewer {
     this.scene.add(backLight);
 
     this.scene.add(new THREE.HemisphereLight(0xffffff, 0x3a3a55, 0.45));
+    this.createStageEnvironment();
 
     // Resize handler
     this.onWindowResize = () => this.refreshLayout();
@@ -137,23 +148,91 @@ export class Zine3DViewer {
     context.fillStyle = '#111111';
     context.fillRect(0, 0, width, height);
 
-    context.strokeStyle = 'rgba(255,255,255,0.18)';
-    context.lineWidth = Math.max(2, width * 0.006);
-    const inset = Math.max(16, width * 0.05);
-    context.strokeRect(inset, inset, width - (inset * 2), height - (inset * 2));
+    const gradient = context.createRadialGradient(width * 0.35, height * 0.2, 0, width * 0.5, height * 0.5, width * 0.7);
+    gradient.addColorStop(0, 'rgba(232,149,95,0.22)');
+    gradient.addColorStop(0.45, 'rgba(232,149,95,0.06)');
+    gradient.addColorStop(1, 'rgba(0,0,0,0)');
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, width, height);
 
-    context.fillStyle = '#f4f1ea';
-    context.fillRect(inset * 1.4, inset * 1.4, width - (inset * 2.8), height - (inset * 2.8));
+    const state = computeMiniZineFoldState(this.fallbackFoldProgress, {
+      w: this.w,
+      h: this.h,
+      stackDepthStep: this.stackDepthStep
+    });
+    const bounds = state.bounds;
+    const useFlatAxis = this.fallbackFoldProgress < 0.95;
+    const modelWidth = Math.max(0.1, bounds.max.x - bounds.min.x);
+    const modelHeight = useFlatAxis
+      ? Math.max(0.1, bounds.max.y - bounds.min.y)
+      : Math.max(0.1, bounds.max.z - bounds.min.z + this.h * 0.75);
+    const scale = Math.min((width * 0.72) / modelWidth, (height * 0.62) / modelHeight);
+    const centerX = (bounds.min.x + bounds.max.x) / 2;
+    const centerY = useFlatAxis
+      ? (bounds.min.y + bounds.max.y) / 2
+      : (bounds.min.z + bounds.max.z) / 2;
+    const pageOrder = [6, 7, 8, 1, 5, 4, 3, 2];
 
-    context.fillStyle = '#ff00d4';
-    context.font = `700 ${Math.max(18, width * 0.06)}px "Bangers", sans-serif`;
+    context.save();
+    context.translate(width / 2, height / 2 + height * 0.02);
+    context.shadowColor = 'rgba(0,0,0,0.28)';
+    context.shadowBlur = Math.max(8, width * 0.018);
+    context.shadowOffsetY = Math.max(4, height * 0.01);
+
+    pageOrder.forEach((pageId) => {
+      const pageState = state.pages[pageId];
+      if (!pageState) {
+        return;
+      }
+      const page = this.fallbackPages[pageId - 1];
+      const loaded = !!(page?.previewUrl || page?.sourceUrl);
+      const x = (pageState.position.x - centerX) * scale;
+      const ySource = useFlatAxis ? -pageState.position.y : -pageState.position.z;
+      const y = (ySource + centerY) * scale;
+      const panelWidth = this.w * scale * (useFlatAxis ? 0.96 : 0.72);
+      const panelHeight = this.h * scale * (useFlatAxis ? 0.96 : 0.45);
+
+      context.save();
+      context.translate(x, y);
+      if (!useFlatAxis) {
+        context.rotate(pageState.rotation.y * 0.18);
+      }
+      context.fillStyle = loaded ? '#fffdf8' : '#f4eadb';
+      context.strokeStyle = pageId === 1 ? '#e8955f' : 'rgba(61,52,40,0.34)';
+      context.lineWidth = Math.max(1, scale * 0.012);
+      context.beginPath();
+      context.roundRect(-panelWidth / 2, -panelHeight / 2, panelWidth, panelHeight, Math.max(3, scale * 0.025));
+      context.fill();
+      context.stroke();
+      context.shadowColor = 'transparent';
+      context.fillStyle = pageId === 1 ? '#9e4529' : '#3d3428';
+      context.font = `700 ${Math.max(11, scale * 0.16)}px Inter, sans-serif`;
+      context.textAlign = 'center';
+      context.textBaseline = 'middle';
+      context.fillText(pageId === 1 ? 'Cover' : `P${pageId}`, 0, 0);
+      context.restore();
+    });
+    context.restore();
+
+    const loadedPages = this.fallbackPages.filter((page) => page?.previewUrl || page?.sourceUrl).length;
+    context.fillStyle = 'rgba(255,253,248,0.86)';
+    context.font = `700 ${Math.max(12, width * 0.026)}px Inter, sans-serif`;
     context.textAlign = 'left';
-    context.fillText('Preview WIP', inset * 1.8, inset * 2.4);
+    context.fillText(`${loadedPages} pages loaded`, Math.max(16, width * 0.05), height - Math.max(18, height * 0.06));
+  }
 
-    context.fillStyle = '#111111';
-    context.font = `${Math.max(12, width * 0.026)}px "Space Grotesk", sans-serif`;
-    context.fillText(`Fold step ${this.fallbackFoldProgress.toFixed(1)}`, inset * 1.8, inset * 3.25);
-    context.fillText(`${this.fallbackPages.filter((page) => page?.previewUrl || page?.sourceUrl).length} pages loaded`, inset * 1.8, inset * 3.85);
+  createStageEnvironment() {
+    const floorGeometry = new THREE.PlaneGeometry(6.2, 4.4);
+    const floorMaterial = new THREE.MeshStandardMaterial({
+      color: 0x1c1713,
+      roughness: 0.92,
+      metalness: 0
+    });
+    const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+    floor.position.z = -0.06;
+    floor.receiveShadow = true;
+    this.scene.add(floor);
+    this.environmentMeshes.push({ mesh: floor, geometry: floorGeometry, material: floorMaterial });
   }
 
   /**
@@ -219,6 +298,7 @@ export class Zine3DViewer {
       let frontMaterial;
       if (url) {
         const texture = textureLoader.load(url);
+        texture.colorSpace = THREE.SRGBColorSpace;
         if (config.isTop) {
           texture.center.set(0.5, 0.5);
           texture.rotation = Math.PI;
@@ -243,10 +323,14 @@ export class Zine3DViewer {
       });
 
       const frontMesh = new THREE.Mesh(frontGeometry, frontMaterial);
+      frontMesh.castShadow = true;
+      frontMesh.receiveShadow = true;
       frontMesh.position.z = this.panelThickness;
       frontMesh.position.y = config.isTop ? this.h / 2 : -this.h / 2;
 
       const backMesh = new THREE.Mesh(backGeometry, backMaterial);
+      backMesh.castShadow = true;
+      backMesh.receiveShadow = true;
       backMesh.rotation.y = Math.PI;
       backMesh.position.z = -this.panelThickness;
       backMesh.position.y = config.isTop ? this.h / 2 : -this.h / 2;
@@ -309,6 +393,7 @@ export class Zine3DViewer {
    * @param {number} progress  0=flat, 1=lengthwise fold, 2=diamond open, 3=closed booklet
    */
   setFoldProgress(progress) {
+    this.currentFoldProgress = progress;
     if (this.isFallbackMode) {
       this.fallbackFoldProgress = progress;
       this.renderFallback();
@@ -360,9 +445,33 @@ export class Zine3DViewer {
       return;
     }
 
-    const zoom = 1 - Math.min(0.22, Math.max(0, progress) * 0.055);
-    const tilt = 0.12 + Math.min(0.12, progress * 0.025);
-    this.camera.position.set(0, Math.sin(tilt) * 0.4, 4.9 * zoom);
+    const bounds = this.debugFoldState?.bounds;
+    if (!bounds) {
+      return;
+    }
+
+    const center = {
+      x: (bounds.min.x + bounds.max.x) / 2,
+      y: (bounds.min.y + bounds.max.y) / 2,
+      z: (bounds.min.z + bounds.max.z) / 2
+    };
+    const span = Math.max(
+      bounds.max.x - bounds.min.x,
+      bounds.max.y - bounds.min.y,
+      bounds.max.z - bounds.min.z,
+      1.6
+    );
+    const stage = Math.max(0, Math.min(3, progress));
+    const yaw = -0.18 + (stage / 3) * 0.32;
+    const lift = 0.25 + (stage / 3) * 0.35;
+    const distance = Math.max(3.1, span * 1.38);
+
+    this.cameraTarget.set(center.x, center.y * 0.35, center.z);
+    this.camera.position.set(
+      this.cameraTarget.x + Math.sin(yaw) * 0.7,
+      this.cameraTarget.y + lift,
+      this.cameraTarget.z + distance
+    );
     this.controls.target.copy(this.cameraTarget);
     this.controls.update();
   }
@@ -379,6 +488,8 @@ export class Zine3DViewer {
         roughness: 0.95
       });
       const mesh = new THREE.Mesh(geometry, material);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
       this.scene.add(mesh);
       this.seams.push({ from, to, orientation, mesh, geometry, material });
     });
@@ -572,5 +683,9 @@ export class Zine3DViewer {
       (guide.geometries ?? [guide.geometry]).forEach((geometry) => geometry?.dispose?.());
     });
     this.renderer.dispose();
+    this.environmentMeshes.forEach(({ geometry, material }) => {
+      geometry?.dispose?.();
+      material?.dispose?.();
+    });
   }
 }

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -49,7 +49,6 @@ export class AppController {
     this.ui.on('pageCropToggled', (i) => this.handlePageCropToggled(i));
     this.ui.on('pageRemoved', (i) => this.handlePageRemoved(i));
     this.ui.on('pagesSwapped', (data) => this.handlePagesSwapped(data));
-    this.ui.on('print', () => this.handlePrint());
     this.ui.on('export', () => this.handleExport());
     this.ui.on('view3d', () => this.handleView3d());
     this.ui.on('clearAll', () => this.handleClearAll());
@@ -596,17 +595,6 @@ export class AppController {
     this.ui.setStatus('Choose files or drop them here');
     this.renderCurrentLayout();
     toast.info('Cleared', 'All pages have been removed.');
-  }
-
-  handlePrint() {
-    if (!this.state.getFilledPageCount()) {
-      toast.warning('No Content', 'Import pages before printing.');
-      return;
-    }
-
-    this.exportService.handlePrint().catch((error) => {
-      toast.error('Print Failed', error.message || 'Unable to print.');
-    });
   }
 
   async getZine3DViewerClass() {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -89,7 +89,7 @@
 .workspace-action-tray,
 .global-action-dock {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.6rem;
   box-sizing: border-box;
   padding: 0.75rem;
@@ -267,7 +267,7 @@ body.mobile-rail-open { overflow: hidden; }
   .workspace-actions,
   .workspace-action-tray,
   .global-action-dock {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -317,8 +317,6 @@ body.mobile-rail-open { overflow: hidden; }
     bottom: calc(var(--mobile-safe-bottom) + 0.5rem);
     z-index: 20;
   }
-
-  .workspace-action-tray > :nth-child(3) { grid-column: 1 / -1; }
 
   .workspace-action-button {
     min-height: 2.75rem;

--- a/src/styles/simulation.css
+++ b/src/styles/simulation.css
@@ -133,15 +133,47 @@
 .simulation-canvas-stage {
   min-height: 24rem;
   height: 100%;
-  border: 1px solid var(--border-color);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-button);
-  background: var(--surface-muted);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(232, 149, 95, 0.16), transparent 34%),
+    radial-gradient(circle at 82% 20%, rgba(255, 253, 248, 0.08), transparent 26%),
+    linear-gradient(145deg, #19130f 0%, #0f0d0b 100%);
   background-image:
-    linear-gradient(var(--border-faint) 1px, transparent 1px),
-    linear-gradient(90deg, var(--border-faint) 1px, transparent 1px);
-  background-size: 20px 20px;
+    radial-gradient(circle at 18% 18%, rgba(232, 149, 95, 0.16), transparent 34%),
+    radial-gradient(circle at 82% 20%, rgba(255, 253, 248, 0.08), transparent 26%),
+    linear-gradient(rgba(255,255,255,0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.045) 1px, transparent 1px),
+    linear-gradient(145deg, #19130f 0%, #0f0d0b 100%);
+  background-size: auto, auto, 24px 24px, 24px 24px, auto;
   overflow: hidden;
   position: relative;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -30px 60px rgba(0,0,0,0.24);
+}
+
+.simulation-canvas-stage::after {
+  content: "fold simulation";
+  position: absolute;
+  left: 0.85rem;
+  bottom: 0.75rem;
+  z-index: 2;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: var(--radius-pill);
+  background: rgba(15, 13, 11, 0.62);
+  color: rgba(255, 253, 248, 0.62);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+.zine-3d-canvas,
+.zine-3d-fallback-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .simulation-sidebar {
@@ -154,26 +186,44 @@
 }
 
 .booklet-preview-container {
-  min-height: 12rem;
+  min-height: 13rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-neutral);
+  background:
+    radial-gradient(circle at 50% 10%, rgba(196, 93, 62, 0.1), transparent 35%),
+    linear-gradient(180deg, var(--surface-muted), var(--bg-neutral));
   border: 1px solid var(--border-color);
   border-radius: var(--radius-button);
-  padding: 1rem;
+  padding: 1.25rem;
   overflow: hidden;
 }
 
 .booklet-shell {
   width: min(100%, 18rem);
+  outline: none;
   perspective: 1200px;
+}
+
+.booklet-shell:focus-visible {
+  border-radius: var(--radius-button);
+  box-shadow: 0 0 0 3px var(--primary-glow);
 }
 
 .booklet-stage {
   aspect-ratio: 2 / 1.414;
+  position: relative;
   transform: rotateX(12deg) rotateY(-14deg);
   transform-style: preserve-3d;
+}
+
+.booklet-shadow {
+  position: absolute;
+  inset: 18% 4% -14%;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(61, 40, 24, 0.22), transparent 68%);
+  filter: blur(8px);
+  transform: translateZ(-28px);
 }
 
 .booklet-spread {
@@ -181,6 +231,7 @@
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
+  filter: drop-shadow(0 14px 18px rgba(61, 40, 24, 0.14));
 }
 
 .booklet-page,
@@ -189,12 +240,15 @@
   top: 0;
   width: 50%;
   height: 100%;
-  background: var(--surface-bg);
+  background:
+    linear-gradient(90deg, rgba(61, 40, 24, 0.08), transparent 8%, transparent 92%, rgba(61, 40, 24, 0.06)),
+    var(--surface-strong);
   border: 1px solid var(--border-color);
   border-radius: 4px;
   overflow: hidden;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 12px rgba(61, 40, 24, 0.12);
   backface-visibility: hidden;
+  transition: box-shadow 0.18s ease, transform 0.18s ease;
 }
 
 .booklet-page-left,
@@ -220,7 +274,7 @@
 }
 
 .booklet-page:hover {
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.14);
+  box-shadow: 0 8px 20px rgba(61, 40, 24, 0.18);
 }
 
 .booklet-spread.is-single-page .booklet-spine {
@@ -270,7 +324,10 @@
 
 .booklet-page-placeholder {
   position: absolute;
-  inset: auto 0 0 0;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0.4rem 0.5rem;
   text-align: center;
   font-size: 0.68rem;
@@ -278,6 +335,23 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--muted-ink);
+}
+
+.booklet-page-label {
+  position: absolute;
+  left: 0.45rem;
+  bottom: 0.45rem;
+  z-index: 2;
+  padding: 0.18rem 0.38rem;
+  border: 1px solid rgba(61, 52, 40, 0.12);
+  border-radius: var(--radius-pill);
+  background: rgba(250, 246, 239, 0.86);
+  color: var(--accent-ink-soft);
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  pointer-events: none;
 }
 
 .booklet-spine {
@@ -322,7 +396,7 @@
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
-  transition: transform 0.55s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transition: transform 0.58s cubic-bezier(0.2, 0.72, 0.22, 1);
 }
 
 .booklet-turn-layer.is-next .booklet-turn-card {

--- a/src/styles/simulation.css
+++ b/src/styles/simulation.css
@@ -185,6 +185,16 @@
   padding-right: 0.2rem;
 }
 
+.simulation-booklet-panel {
+  position: relative;
+  z-index: 2;
+}
+
+.simulation-guide-panel {
+  position: relative;
+  z-index: 1;
+}
+
 .booklet-preview-container {
   min-height: 13rem;
   display: flex;

--- a/src/styles/simulation.css
+++ b/src/styles/simulation.css
@@ -479,6 +479,7 @@
   background: var(--surface-muted);
   padding: 0.5rem;
   image-rendering: crisp-edges;
+  pointer-events: none;
 }
 
 @media (max-width: 1023px) {

--- a/tests/e2e/3d_preview.spec.js
+++ b/tests/e2e/3d_preview.spec.js
@@ -128,6 +128,7 @@ test('booklet preview reflects flip adjustments from the sheet preview', async (
 
   await expect(page.locator('#upload-status')).toContainText('Imported image: cover-map.png', { timeout: 30000 });
 
+  await page.locator('.page-cell[data-page-index="0"]').hover();
   await page.getByRole('button', { name: 'Rotate Cover 180 degrees (R)' }).click();
   await page.locator('#view3dBtn').click();
 

--- a/tests/e2e/3d_preview.spec.js
+++ b/tests/e2e/3d_preview.spec.js
@@ -86,6 +86,7 @@ test('opens the 3D preview modal with a sized canvas', async ({ page }) => {
 
   await expect(page.locator('#upload-status')).toContainText('Imported 1 of 1 pages from 3d-preview.pdf', { timeout: 30000 });
 
+  await expect(page.locator('#printBtn')).toHaveCount(0);
   await page.locator('#view3dBtn').click();
 
   const modal = page.locator('#zine-3d-modal');
@@ -127,7 +128,7 @@ test('booklet preview reflects flip adjustments from the sheet preview', async (
 
   await expect(page.locator('#upload-status')).toContainText('Imported image: cover-map.png', { timeout: 30000 });
 
-  await page.locator('button[title="Flip Cover"]').click();
+  await page.getByRole('button', { name: 'Rotate Cover 180 degrees (R)' }).click();
   await page.locator('#view3dBtn').click();
 
   const modal = page.locator('#zine-3d-modal');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removed the broken Print action from the main action dock and app event wiring.
- Added synchronized fold preview state for slider, step buttons, helper text, status chips, and number-key shortcuts.
- Refreshed the fold simulation and booklet preview visuals with a clearer stage, improved WebGL lighting/camera, and a real canvas fallback diagram.
- Updated focused preview coverage for the removed print button and current rotation control label.

## Testing
- `pnpm lint` (passes with existing `src/services/PDFProcessor.js` no-console warning)
- `PATH="$PWD/.tmp-bin:$PATH" pnpm exec playwright test tests/unit/mini_zine_fold.spec.js tests/unit/mini_zine_layout.spec.js tests/e2e/3d_preview.spec.js` (9 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8361793-8b05-4591-8331-3372ea9c45d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8361793-8b05-4591-8331-3372ea9c45d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

