### PR TITLE
Add AGENTS.md for Cursor Cloud development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Zine-ify
+
+A client-side PWA that converts PDFs into printable 8-page mini zine layouts. No backend services or databases.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | Command | Port |
+|---------|---------|------|
+| Dev server | `pnpm dev` | 5000 |
+
+### Key commands
+
+See `package.json` `scripts` for the full list. Highlights:
+
+- **Lint:** `pnpm lint` (lints `src/`)
+- **Build:** `pnpm build`
+- **Dev server:** `pnpm dev` (Vite, port 5000, host 0.0.0.0)
+- **Tests:** `pnpm test` (Playwright — builds first, serves on port 8001)
+
+### Gotchas
+
+- The Playwright `webServer` command in `playwright.config.js` calls `python -m http.server`. On environments where only `python3` is available, ensure a `python` symlink exists: `sudo ln -sf /usr/bin/python3 /usr/local/bin/python`.
+- Playwright tests require Chromium: run `pnpm exec playwright install --with-deps chromium` if browsers are not yet installed.
+- Some e2e tests (3D preview, mobile layout, mixed uploads, multi-file queue) have pre-existing failures unrelated to environment setup.
+- The test PDF generator script is at `scripts/create_test_pdf.js` — run with `node scripts/create_test_pdf.js` to create a sample 16-page PDF for manual testing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development instructions for Cursor Cloud agents, including:

- Service table (dev server on port 5000)
- Key commands for lint, build, dev, and test
- Environment gotchas (python symlink for Playwright, Chromium installation, pre-existing test failures)

[demo_zineify_pdf_upload_and_export.mp4](https://cursor.com/agents/bc-aab63b62-486d-4b41-9a63-cdb6717456c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_zineify_pdf_upload_and_export.mp4)
Uploaded a 16-page test PDF, imported pages into zine layout, and exported the result.

[Zine layout with 8 PDF pages in grid](https://cursor.com/agents/bc-aab63b62-486d-4b41-9a63-cdb6717456c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzine_layout_with_pages.webp)
[Export PDF success](https://cursor.com/agents/bc-aab63b62-486d-4b41-9a63-cdb6717456c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexport_pdf_success.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aab63b62-486d-4b41-9a63-cdb6717456c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aab63b62-486d-4b41-9a63-cdb6717456c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

