### PR TITLE
🧹 [Code Health] Refactor createSheetGrid to use template object

### DIFF
--- a/src/components/UI/LayoutRenderer.js
+++ b/src/components/UI/LayoutRenderer.js
@@ -33,9 +33,7 @@ export class LayoutRenderer {
     for (let s = 0; s < sheetCount; s++) {
       const { sheetWrapper, grid } = this.createSheetGrid({
         sheetNumber: s + 1,
-        template: template.label,
-        columns: template.grid.cols,
-        rows: template.grid.rows,
+        template,
         id: `zine-grid-sheet-${s + 1}`,
         paper
       });
@@ -111,11 +109,11 @@ export class LayoutRenderer {
     return { page: index + 1, upsideDown: false };
   }
 
-  createSheetGrid({ sheetNumber, template, columns, rows, id, paper }) {
+  createSheetGrid({ sheetNumber, template, id, paper }) {
     const sheetWrapper = document.createElement('div');
     sheetWrapper.className = 'print-sheet w-full p-0 relative overflow-hidden rounded-sm';
     sheetWrapper.setAttribute('data-sheet', sheetNumber);
-    sheetWrapper.setAttribute('data-template', template);
+    sheetWrapper.setAttribute('data-template', template.label);
 
     if (paper?.paperSize) {
       sheetWrapper.setAttribute('data-paper-size', paper.paperSize);
@@ -139,8 +137,8 @@ export class LayoutRenderer {
     grid.className = 'zine-grid';
     grid.id = id;
     grid.style.display = 'grid';
-    grid.style.gridTemplateColumns = `repeat(${columns}, 1fr)`;
-    grid.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+    grid.style.gridTemplateColumns = `repeat(${template.grid.cols}, 1fr)`;
+    grid.style.gridTemplateRows = `repeat(${template.grid.rows}, 1fr)`;
 
     if (paper?.margin > 0 && paper?.width && paper?.height) {
       const padX = (paper.margin / paper.width) * 100;


### PR DESCRIPTION
🎯 What:
Refactored the `createSheetGrid` signature in `src/components/UI/LayoutRenderer.js` to accept the entire `template` object directly instead of manually destructured individual properties (`columns` and `rows` and `template` string).

💡 Why:
This improves readability and maintainability by simplifying the method parameters. It resolves a code health issue where too many parameters were being extracted and passed manually, reducing the surface area of the function signature. The method can now internally derive grid dimensions and layout metadata directly from the structured `template` object.

✅ Verification:
1. Ran `pnpm test tests/unit/mini_zine_layout.spec.js tests/unit/pdf_processor.spec.js tests/e2e/layout_config.spec.js` and confirmed existing test coverage did not regress.
2. The failing test `tests/e2e/layout_config.spec.js` is pre-existing (confirmed via testing the unmodified codebase with git stash).

✨ Result:
Cleaned up method signature and caller, establishing a cleaner single-object options pattern for sheet grid creation.

---
*PR created automatically by Jules for task [15562005695939073189](https://jules.google.com/task/15562005695939073189) started by @guitarbeat*