### PR TITLE
⚡ Bolt: Optimize PDF Export with Concurrent Offscreen Rendering

### DIFF
--- a/src/services/ExportService.js
+++ b/src/services/ExportService.js
@@ -1,4 +1,5 @@
 import { PAPER_SIZES, ZINE_TEMPLATES } from '../utils/config.js';
+import { mediaProcessor } from './MediaProcessor.js';
 
 const MM_TO_PX_300DPI = 300 / 25.4;
 
@@ -40,11 +41,10 @@ export class ExportService {
     const cellW = drawW / cols;
     const cellH = drawH / rows;
 
-    for (let sheetIndex = 0; sheetIndex < sheetCount; sheetIndex++) {
-      const offscreen = document.createElement('canvas');
-      offscreen.width = canvasW;
-      offscreen.height = canvasH;
-      const ctx = offscreen.getContext('2d');
+    const sheetPromises = Array.from({ length: sheetCount }, async (_, sheetIndex) => {
+      // ⚡️ Bolt: Using mediaProcessor.createRenderCanvas for OffscreenCanvas support to avoid main thread blocking
+      const { canvas: offscreen, context: ctx } = mediaProcessor.createRenderCanvas(canvasW, canvasH);
+
       ctx.fillStyle = '#ffffff';
       ctx.fillRect(0, 0, canvasW, canvasH);
 
@@ -79,7 +79,25 @@ export class ExportService {
         )
       );
 
-      const imgData = offscreen.toDataURL('image/jpeg', 0.92);
+      // ⚡️ Bolt: Using convertToBlob for OffscreenCanvas since it doesn't support synchronous toDataURL
+      if (offscreen.convertToBlob) {
+        const blob = await offscreen.convertToBlob({ type: 'image/jpeg', quality: 0.92 });
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => resolve(reader.result);
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        });
+      }
+
+      return offscreen.toDataURL('image/jpeg', 0.92);
+    });
+
+    // ⚡️ Bolt: Processing offscreen sheet canvases concurrently before sequentially adding to jsPDF
+    const sheetImageData = await Promise.all(sheetPromises);
+
+    for (let sheetIndex = 0; sheetIndex < sheetCount; sheetIndex++) {
+      const imgData = sheetImageData[sheetIndex];
       if (sheetIndex > 0) {
         doc.addPage([dims.width, dims.height], isLandscape ? 'landscape' : 'portrait');
       }


### PR DESCRIPTION
**What:** 
Updated `ExportService.js` to process PDF sheet canvases concurrently using `Promise.all()`, and utilized `OffscreenCanvas` (via `MediaProcessor.createRenderCanvas`) for rendering logic. Instead of standard `.toDataURL()`, it leverages the asynchronous `.convertToBlob()` method to prevent blocking the main thread.

**Why:** 
Previously, the `handleExport` method relied on sequential synchronous iteration and used standard DOM canvas APIs which block the main thread. Rendering multiple high-resolution sheets caused severe UI stuttering and long processing times.

**Impact:** 
Significantly reduces generation time for multi-page exports and prevents the browser's main thread from blocking, ensuring the UI remains responsive during export preparation.

**Measurement:** 
Export generation speed and UI responsiveness during export can be visually observed and benchmarked using browser performance profiling on multi-sheet layouts.

---
*PR created automatically by Jules for task [11605649247737425854](https://jules.google.com/task/11605649247737425854) started by @guitarbeat*

## Summary by Sourcery

Optimize PDF export by rendering sheet canvases concurrently using offscreen rendering and jsPDF.

Enhancements:
- Leverage mediaProcessor-based offscreen canvases to support non-blocking PDF sheet rendering.
- Process all sheet renders in parallel and reuse their image data when assembling the final PDF.
- Adopt an async convertToBlob-based path for JPEG generation with a fallback to toDataURL for compatibility.