### PR TITLE
⚡ Bolt: Optimize PDF export to be concurrent and unblock the UI

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2024-05-20 - Toast Component Cloning Optimization
 **Learning:** Repetitive UI components like Toast notifications constructed using multiple `document.createElement()` and property assignment calls cause unnecessary DOM processing overhead and memory allocation, especially when an object like `icons` is recreated on every invocation.
 **Action:** Extract static dictionary objects into module-level constants to save memory allocation, and use HTML `<template>` combined with `cloneNode(true)` to build repetitive elements instantly, minimizing layout thrashing and function call overhead.
+## 2024-06-11 - Optimized PDF Export with Async OffscreenCanvas
+**Learning:** The previous implementation used synchronous `offscreen.toDataURL('image/jpeg')` which blocked the main thread during high-resolution canvas conversions, leading to UI freezes, particularly when exporting PDFs containing many high-resolution pages.
+**Action:** Replaced synchronous `toDataURL` with the asynchronous `OffscreenCanvas.convertToBlob()` API and processed all sheets concurrently with `Promise.all` mapping to improve export speed and unblock the UI. We must always prefer asynchronous `convertToBlob` + `FileReader.readAsDataURL` when extracting image data from an `OffscreenCanvas`.

--- a/src/services/ExportService.js
+++ b/src/services/ExportService.js
@@ -1,4 +1,5 @@
 import { PAPER_SIZES, ZINE_TEMPLATES } from '../utils/config.js';
+import { mediaProcessor } from './MediaProcessor.js';
 
 const MM_TO_PX_300DPI = 300 / 25.4;
 
@@ -40,11 +41,9 @@ export class ExportService {
     const cellW = drawW / cols;
     const cellH = drawH / rows;
 
-    for (let sheetIndex = 0; sheetIndex < sheetCount; sheetIndex++) {
-      const offscreen = document.createElement('canvas');
-      offscreen.width = canvasW;
-      offscreen.height = canvasH;
-      const ctx = offscreen.getContext('2d');
+    // ⚡️ Bolt: Process offscreen sheet canvases concurrently to improve PDF generation performance.
+    const sheetPromises = Array.from({ length: sheetCount }).map(async (_, sheetIndex) => {
+      const { canvas: offscreen, context: ctx } = mediaProcessor.createRenderCanvas(canvasW, canvasH);
       ctx.fillStyle = '#ffffff';
       ctx.fillRect(0, 0, canvasW, canvasH);
 
@@ -79,11 +78,25 @@ export class ExportService {
         )
       );
 
-      const imgData = offscreen.toDataURL('image/jpeg', 0.92);
+      // ⚡️ Bolt: Optimize export by replacing synchronous canvas.toDataURL with asynchronous OffscreenCanvas convertToBlob
+      if (offscreen.convertToBlob) {
+        const blob = await offscreen.convertToBlob({ type: 'image/jpeg', quality: 0.92 });
+        return new Promise((resolve) => {
+          const reader = new FileReader();
+          reader.onloadend = () => resolve(reader.result);
+          reader.readAsDataURL(blob);
+        });
+      }
+      return offscreen.toDataURL('image/jpeg', 0.92);
+    });
+
+    const sheetImages = await Promise.all(sheetPromises);
+
+    for (let sheetIndex = 0; sheetIndex < sheetCount; sheetIndex++) {
       if (sheetIndex > 0) {
         doc.addPage([dims.width, dims.height], isLandscape ? 'landscape' : 'portrait');
       }
-      doc.addImage(imgData, 'JPEG', 0, 0, dims.width, dims.height);
+      doc.addImage(sheetImages[sheetIndex], 'JPEG', 0, 0, dims.width, dims.height);
     }
 
     doc.save('zine.pdf');


### PR DESCRIPTION
💡 **What:** Migrated the PDF generation process in `ExportService.js` to process sheets concurrently using `Promise.all`. Replaced the synchronous, main-thread blocking `canvas.toDataURL()` method with the asynchronous `OffscreenCanvas.convertToBlob()` API and `FileReader`. Encapsulated canvas creation via `mediaProcessor.createRenderCanvas()`.

🎯 **Why:** The previous sequential `for` loop combined with `toDataURL()` forced the browser to encode high-resolution image data synchronously on the main thread. When users exported PDFs with many pages or high-resolution layouts, this caused significant UI freezing.

📊 **Impact:** Dramatically reduces main thread blocking during export, avoiding "page unresponsive" warnings. Utilizing background threads for blob conversion should also reduce export time for multi-sheet layouts by leveraging concurrent rendering.

🔬 **Measurement:** Can be verified by running the application, loading a large multi-page PDF, clicking "Export", and observing the UI responsiveness. The tests pass and no longer block execution on single-thread Node environments.

---
*PR created automatically by Jules for task [674093061313893330](https://jules.google.com/task/674093061313893330) started by @guitarbeat*

## Summary by Sourcery

Optimize PDF export to generate sheet images concurrently and reduce main-thread blocking during export.

Enhancements:
- Process PDF sheet rendering canvases concurrently using promises to improve export performance and responsiveness.
- Switch PDF sheet image extraction from synchronous canvas.toDataURL to asynchronous OffscreenCanvas.convertToBlob with a FileReader fallback.
- Centralize render canvas creation through mediaProcessor.createRenderCanvas for sheet exports.

Documentation:
- Document the PDF export optimization and learnings in the Bolt engineering notes.