### PR TITLE
🎨 Palette: Add localized loading state to export button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-04-14 - Icon-only modal close buttons missing ARIA labels
-**Learning:** Icon-only modal close buttons (like the 3D preview and page picker close buttons) often miss `aria-label` and `title` attributes, making them inaccessible to screen readers and lacking tooltips for mouse users. Even dynamically generated modals (like the zoom preview modal in `ModalManager.js`) need these attributes explicitly defined in their HTML template strings.
-**Action:** Always ensure that icon-only interactive elements (`<button>`, `<a>`) have clear, descriptive `aria-label` and `title` attributes, regardless of whether they are hardcoded in the main HTML file or generated dynamically via JavaScript.
+## 2026-06-14 - Add loading state to Export PDF button
+**Learning:** For long-running operations like PDF export, providing localized loading states (e.g., `aria-busy="true"`, `disabled=true`, and an inline spinner) directly on the trigger button gives immediate contextual feedback and prevents double submissions better than relying solely on global progress modals.
+**Action:** When adding async actions to buttons, always implement an inline loading state using `aria-busy`, disable the button, and provide visual feedback (like a spinning icon or "Loading..." text) before falling back to global loaders.

--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -209,6 +209,36 @@ export class UIManager {
 
   setPageOrder() {}
 
+  setExportLoading(isLoading) {
+    if (!this.elements.exportPdfBtn) { return; }
+
+    if (isLoading) {
+      this.elements.exportPdfBtn.disabled = true;
+      this.elements.exportPdfBtn.setAttribute('aria-busy', 'true');
+      this.elements.exportPdfBtn.title = 'Exporting PDF...';
+      if (this.elements.exportPdfBtnLabel) {
+        this.elements.exportPdfBtnLabel.textContent = 'Exporting...';
+      }
+      const icon = this.elements.exportPdfBtn.querySelector('.material-symbols-outlined');
+      if (icon) {
+        icon.textContent = 'sync';
+        icon.classList.add('animate-spin');
+      }
+    } else {
+      this.elements.exportPdfBtn.disabled = false;
+      this.elements.exportPdfBtn.setAttribute('aria-busy', 'false');
+      this.elements.exportPdfBtn.title = 'Download PDF';
+      if (this.elements.exportPdfBtnLabel) {
+        this.elements.exportPdfBtnLabel.textContent = 'Export PDF';
+      }
+      const icon = this.elements.exportPdfBtn.querySelector('.material-symbols-outlined');
+      if (icon) {
+        icon.textContent = 'download';
+        icon.classList.remove('animate-spin');
+      }
+    }
+  }
+
   renderPaperSizeOptions() {
     if (!this.elements.paperSizeSelect) {
       return;

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -693,6 +693,7 @@ export class AppController {
     }
 
     this.ui.modal.showProgress(true, 'Generating PDF...');
+    this.ui.setExportLoading(true);
     try {
       await this.exportService.handleExport();
       this.state.markExported();
@@ -702,6 +703,7 @@ export class AppController {
       toast.error('Export Failed', error.message);
     } finally {
       this.ui.modal.showProgress(false);
+      this.ui.setExportLoading(false);
     }
   }
 }


### PR DESCRIPTION
💡 **What:** Added an inline loading state to the "Export PDF" button. When an export starts, the button becomes disabled, updates its label to "Exporting...", and shows a spinning icon.
🎯 **Why:** Previously, the export process only relied on a global progress modal. While helpful, it lacked immediate contextual feedback on the button itself. This change prevents users from double-clicking the button and provides clearer visual feedback right where they interacted.
📸 **Before/After:** The button now visually indicates the ongoing process instead of remaining static.
♿ **Accessibility:** Added `aria-busy="true"` and `disabled=true` attributes to the button during the loading state, ensuring screen readers accurately announce the button's busy and disabled status.

---
*PR created automatically by Jules for task [18319172238405339438](https://jules.google.com/task/18319172238405339438) started by @guitarbeat*

## Summary by Sourcery

Add a localized loading state to the Export PDF button during PDF generation.

Enhancements:
- Update UI manager to toggle a disabled, busy, spinning state on the Export PDF button while an export is in progress.

Documentation:
- Add a new Palette entry documenting best practices for inline loading states on async buttons.