### PR TITLE
🎨 Palette: Add accessible labels to interactive buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-14 - Icon-only modal close buttons missing ARIA labels
 **Learning:** Icon-only modal close buttons (like the 3D preview and page picker close buttons) often miss `aria-label` and `title` attributes, making them inaccessible to screen readers and lacking tooltips for mouse users. Even dynamically generated modals (like the zoom preview modal in `ModalManager.js`) need these attributes explicitly defined in their HTML template strings.
 **Action:** Always ensure that icon-only interactive elements (`<button>`, `<a>`) have clear, descriptive `aria-label` and `title` attributes, regardless of whether they are hardcoded in the main HTML file or generated dynamically via JavaScript.
+
+## 2026-06-12 - Explicit Labels for Visual Grid & Preset Components
+**Learning:** When building visual interactive grids (like the PDF page picker thumbnails) or preset constraint chips ("First 8", "Odd", "Even"), the contextual text or internal image alt-text is often insufficient for robust screen reader navigation. Users rely heavily on explicit `aria-label` attributes to understand the exact action (e.g., "Select page 1" instead of just hearing the image alt text).
+**Action:** Always ensure that interactive buttons wrapping complex media or acting as layout presets have explicit, action-oriented `aria-label`s defined during DOM construction.

--- a/index.html
+++ b/index.html
@@ -300,11 +300,11 @@
                         <div id="booklet-preview-container" class="booklet-preview-container" aria-label="Small booklet preview"></div>
 
                         <div class="grid grid-cols-2 gap-2.5">
-                            <button id="booklet-prev-btn" class="action-button w-full py-2 px-3 flex items-center justify-center gap-1.5 bg-white text-zinc-800 font-medium text-sm" type="button">
+                            <button id="booklet-prev-btn" class="action-button w-full py-2 px-3 flex items-center justify-center gap-1.5 bg-white text-zinc-800 font-medium text-sm" type="button" aria-label="Previous page">
                                 <span class="material-symbols-outlined text-base" aria-hidden="true">chevron_left</span>
                                 Prev
                             </button>
-                            <button id="booklet-next-btn" class="action-button w-full py-2 px-3 flex items-center justify-center gap-1.5 bg-zinc-900 text-white font-medium text-sm" type="button">
+                            <button id="booklet-next-btn" class="action-button w-full py-2 px-3 flex items-center justify-center gap-1.5 bg-zinc-900 text-white font-medium text-sm" type="button" aria-label="Next page">
                                 Next
                                 <span class="material-symbols-outlined text-base" aria-hidden="true">chevron_right</span>
                             </button>
@@ -401,11 +401,11 @@
 
             <div class="page-picker-toolbar px-5 py-3 border-b border-zinc-100 flex flex-col gap-2.5">
                 <div class="page-picker-presets flex flex-wrap items-center gap-1.5">
-                    <button id="page-picker-select-first" type="button" class="page-picker-chip">First 8</button>
-                    <button id="page-picker-select-last" type="button" class="page-picker-chip">Last 8</button>
-                    <button id="page-picker-select-even" type="button" class="page-picker-chip">Even</button>
-                    <button id="page-picker-select-odd" type="button" class="page-picker-chip">Odd</button>
-                    <button id="page-picker-clear" type="button" class="page-picker-chip">Clear</button>
+                    <button id="page-picker-select-first" type="button" class="page-picker-chip" aria-label="Select first 8 pages">First 8</button>
+                    <button id="page-picker-select-last" type="button" class="page-picker-chip" aria-label="Select last 8 pages">Last 8</button>
+                    <button id="page-picker-select-even" type="button" class="page-picker-chip" aria-label="Select even pages">Even</button>
+                    <button id="page-picker-select-odd" type="button" class="page-picker-chip" aria-label="Select odd pages">Odd</button>
+                    <button id="page-picker-clear" type="button" class="page-picker-chip" aria-label="Clear page selection">Clear</button>
                 </div>
                 <div class="page-picker-status flex flex-wrap items-center justify-between gap-2">
                     <p id="page-picker-count" class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">

--- a/src/components/UI/PagePicker.js
+++ b/src/components/UI/PagePicker.js
@@ -100,6 +100,7 @@ export class PagePicker {
       btn.className = 'page-picker-thumb';
       btn.dataset.pageNumber = String(pageNumber);
       btn.setAttribute('aria-pressed', initialSelection.includes(pageNumber) ? 'true' : 'false');
+      btn.setAttribute('aria-label', `Select page ${pageNumber}`);
 
       const media = document.createElement('div');
       media.className = 'page-picker-thumb-media';


### PR DESCRIPTION
### 💡 What:
Added explicit `aria-label` attributes to several interactive elements across the application, including:
- The Page Picker preset chips ("First 8", "Last 8", etc.) in `index.html`.
- The Booklet preview pagination buttons ("Prev", "Next") in `index.html`.
- The dynamically generated page selection thumbnails in `PagePicker.js`.
- A new entry in `.jules/palette.md` documenting this UX learning.

### 🎯 Why:
While these interactive components had text or nested images with alt text, they often lacked a direct, action-oriented label for screen readers. Explicit `aria-label` attributes improve keyboard and screen reader accessibility by directly communicating the interactive consequence (e.g., "Select first 8 pages" instead of just "First 8").

### 📸 Before/After:
*Visuals unchanged. Changes are internal HTML attributes for assistive technologies.*

### ♿ Accessibility:
Improved screen reader robust navigation on the primary selection grids and preset chips.

---
*PR created automatically by Jules for task [11504698286356235481](https://jules.google.com/task/11504698286356235481) started by @guitarbeat*