### PR TITLE
⚡ Bolt: O(n) to O(1) page-cell query cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2024-05-20 - Toast Component Cloning Optimization
 **Learning:** Repetitive UI components like Toast notifications constructed using multiple `document.createElement()` and property assignment calls cause unnecessary DOM processing overhead and memory allocation, especially when an object like `icons` is recreated on every invocation.
 **Action:** Extract static dictionary objects into module-level constants to save memory allocation, and use HTML `<template>` combined with `cloneNode(true)` to build repetitive elements instantly, minimizing layout thrashing and function call overhead.
+## 2026-06-18 - Repeated DOM Querying in Event Handlers
+**Learning:** Frequent DOM queries via `querySelector` in event handlers or tight loops (e.g., fetching `.page-cell` elements by index in `UIManager`) can cause unnecessary O(n) performance degradation, especially as grid complexity increases.
+**Action:** Implement DOM Caching using a `Map` during the initial query to transform subsequent lookups from O(n) to O(1). Be sure to invalidate the cache when the DOM structure is rebuilt (e.g., during layout generation).

--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -80,18 +80,16 @@ export class UIManager {
 
   initSmartSheetConfig() {
     const container = document.getElementById('smart-sheet-config-container');
-    if (!container) return;
-
-    let lastGridState = { rows: DEFAULT_GRID_ROWS, cols: DEFAULT_GRID_COLS };
+    if (!container) {return;}
 
     let lastGridState = { rows: DEFAULT_GRID_ROWS, cols: DEFAULT_GRID_COLS };
 
     this.smartSheetConfig = new SmartSheetConfig(container, {
       initialRows: DEFAULT_GRID_ROWS,
       initialCols: DEFAULT_GRID_COLS,
-      onChange: ({ rows, cols, paperSize, orientation, margin, totalSlots }) => {
-        if (this.elements.gridRows) this.elements.gridRows.value = rows;
-        if (this.elements.gridCols) this.elements.gridCols.value = cols;
+      onChange: ({ rows, cols, paperSize, orientation, margin, _totalSlots }) => {
+        if (this.elements.gridRows) {this.elements.gridRows.value = rows;}
+        if (this.elements.gridCols) {this.elements.gridCols.value = cols;}
         this.updateGridTotalBadge(rows, cols);
         this._syncOrientationVisibility(rows, cols);
 
@@ -309,7 +307,7 @@ export class UIManager {
   }
 
   _syncOrientationVisibility(rows, cols) {
-    if (this.smartSheetConfig) return;
+    if (this.smartSheetConfig) {return;}
     const isMini8 = rows === 2 && cols === 4;
     const wrapper = this.elements.orientationToggle?.closest('.workspace-config-field');
     if (wrapper) {
@@ -349,7 +347,21 @@ export class UIManager {
   }
 
   _getPageCell(index) {
-    return this.elements.zineSheetsContainer?.querySelector(`[data-page-index="${index}"]`) || null;
+    if (!this.pageCellCache) {
+      const cells = this.elements.zineSheetsContainer?.querySelectorAll('.page-cell');
+      if (cells && cells.length > 0) {
+        this.pageCellCache = new Map();
+        cells.forEach(cell => {
+          const idx = parseInt(cell.getAttribute('data-page-index'), 10);
+          if (!isNaN(idx)) {
+            this.pageCellCache.set(idx, cell);
+          }
+        });
+      } else {
+        return this.elements.zineSheetsContainer?.querySelector(`[data-page-index="${index}"]`) || null;
+      }
+    }
+    return this.pageCellCache?.get(parseInt(index, 10)) || null;
   }
 
   getPaperDimensions(paperSizeKey, orientation) {
@@ -535,6 +547,7 @@ export class UIManager {
     });
 
     if (!this.smartSheetConfig) {
+      let lastGridState = { rows: DEFAULT_GRID_ROWS, cols: DEFAULT_GRID_COLS };
       const debouncedGridChange = debounce(() => {
         const { rows, cols } = this.normalizeGridInputs();
 
@@ -563,6 +576,8 @@ export class UIManager {
   }
 
   generateLayout(numPages, templateType, paperSettings = {}) {
+    this.pageCellCache = null;
+
     const template = typeof templateType === 'string'
       ? ZINE_TEMPLATES[templateType || 'mini-8']
       : (templateType || ZINE_TEMPLATES['mini-8']);


### PR DESCRIPTION
💡 **What**:
Implement DOM Query Caching for `.page-cell` elements in `UIManager.js`.

🎯 **Why**:
Repeatedly calling `querySelector` inside `_getPageCell` during UI updates (like adding/removing pages or changing orientations) executes an O(n) search over the DOM tree every time. This bottleneck scales poorly as the grid complexity increases (e.g., larger paper layouts).

📊 **Impact**:
Reduces O(n) DOM querying to an O(1) `Map` lookup for subsequent page operations. This decreases rendering execution time and reduces layout thrashing, improving perceived performance on larger zine sizes.

🔬 **Measurement**:
Tested manually and verified tests passed using `pnpm run test` and `npx playwright test`. Checked `.page-cell` operations in layout mode to ensure caching doesn't return stale references during layout regenerations.

---
*PR created automatically by Jules for task [17985195894481386891](https://jules.google.com/task/17985195894481386891) started by @guitarbeat*

## Summary by Sourcery

Introduce a cached lookup for `.page-cell` elements to improve UI layout performance and document the optimization in Bolt notes.

Enhancements:
- Cache `.page-cell` DOM elements in `UIManager` using a `Map` for O(1) lookup and reset the cache when regenerating layouts.
- Refine UI manager control flow and parameter handling in grid/orientation configuration callbacks.
- Extend the internal Bolt notes with guidance on avoiding repeated DOM queries and using caching strategies.

Documentation:
- Update Bolt engineering notes with a new entry describing the DOM query caching optimization and when to invalidate caches.