### PR TITLE
🎨 Palette: Add localized loading state to export button

### DIFF
--- a/jules_palette_script.js
+++ b/jules_palette_script.js
@@ -1,0 +1,8 @@
+const ui = {
+  elements: {
+    exportPdfBtn: { disabled: false, setAttribute: () => {}, querySelector: () => {} }
+  }
+};
+// Add aria-busy logic to UIManager and AppController or just the button?
+// AppController handles the click and calls exportService.
+// Let's modify handleExport in AppController to set aria-busy="true" and disabled on the button itself.

--- a/patch_export_ux.cjs
+++ b/patch_export_ux.cjs
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join(__dirname, 'src/core/AppController.js');
+let code = fs.readFileSync(filePath, 'utf8');
+
+const target = `    this.ui.modal.showProgress(true, 'Generating PDF...');
+    try {
+      await this.exportService.handleExport();`;
+
+const replacement = `    // Provide localized loading state directly on the button per memory instructions
+    if (this.ui.elements.exportPdfBtn) {
+      this.ui.elements.exportPdfBtn.setAttribute('aria-busy', 'true');
+      this.ui.elements.exportPdfBtn.disabled = true;
+      this.ui.elements.exportPdfBtn.innerHTML = '<span class="material-symbols-outlined animate-spin" aria-hidden="true">sync</span><span class="text-sm font-semibold">Generating PDF...</span>';
+    }
+
+    this.ui.modal.showProgress(true, 'Generating PDF...');
+    try {
+      await this.exportService.handleExport();`;
+
+code = code.replace(target, replacement);
+
+const targetFinally = `    } catch (error) {
+      toast.error('Export Failed', error.message);
+    } finally {
+      this.ui.modal.showProgress(false);
+    }`;
+
+const replacementFinally = `    } catch (error) {
+      toast.error('Export Failed', error.message);
+    } finally {
+      this.ui.modal.showProgress(false);
+
+      // Restore button state
+      if (this.ui.elements.exportPdfBtn) {
+        this.ui.elements.exportPdfBtn.removeAttribute('aria-busy');
+        this.ui.elements.exportPdfBtn.disabled = false;
+        this.ui.elements.exportPdfBtn.innerHTML = '<span class="material-symbols-outlined" aria-hidden="true">print</span><span class="text-sm font-semibold">Export PDF</span>';
+      }
+    }`;
+
+code = code.replace(targetFinally, replacementFinally);
+
+fs.writeFileSync(filePath, code, 'utf8');
+console.log('Patched AppController.js');

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -696,6 +696,13 @@ export class AppController {
       return;
     }
 
+    // Provide localized loading state directly on the button per memory instructions
+    if (this.ui.elements.exportPdfBtn) {
+      this.ui.elements.exportPdfBtn.setAttribute('aria-busy', 'true');
+      this.ui.elements.exportPdfBtn.disabled = true;
+      this.ui.elements.exportPdfBtn.innerHTML = '<span class="material-symbols-outlined animate-spin" aria-hidden="true">sync</span><span class="text-sm font-semibold">Generating PDF...</span>';
+    }
+
     this.ui.modal.showProgress(true, 'Generating PDF...');
     try {
       await this.exportService.handleExport();
@@ -706,6 +713,13 @@ export class AppController {
       toast.error('Export Failed', error.message);
     } finally {
       this.ui.modal.showProgress(false);
+
+      // Restore button state
+      if (this.ui.elements.exportPdfBtn) {
+        this.ui.elements.exportPdfBtn.removeAttribute('aria-busy');
+        this.ui.elements.exportPdfBtn.disabled = false;
+        this.ui.elements.exportPdfBtn.innerHTML = '<span class="material-symbols-outlined" aria-hidden="true">print</span><span class="text-sm font-semibold">Export PDF</span>';
+      }
     }
   }
 }

--- a/test_spinner.html
+++ b/test_spinner.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
+</head>
+<body>
+  <span class="material-symbols-outlined animate-spin" aria-hidden="true">sync</span>
+</body>
+</html>


### PR DESCRIPTION
💡 What: Added a localized loading state (spinning sync icon and "Generating PDF...") directly to the "Export PDF" trigger button during the async PDF generation process, replacing the static state, and then restored it afterward.
🎯 Why: Relying solely on global progress modals for long-running async tasks disconnects the user from the interaction point. The button itself loses context of the action it just triggered. This localized state provides immediate contextual feedback where the user is looking.
📸 Before/After: Visual changes demonstrated in Playwright script.
♿ Accessibility: The button is marked `disabled=true` and gets `aria-busy="true"` during the operation, improving feedback for screen readers.

---
*PR created automatically by Jules for task [8387495479951623464](https://jules.google.com/task/8387495479951623464) started by @guitarbeat*