### PR TITLE
Implement file upload section and branded app header

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
     <meta name="description" content="Import pages, arrange a printable zine sheet, preview the fold, and export." />
-    <meta name="theme-color" content="#c45d3e" />
+    <meta name="theme-color" content="#c0512f" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
@@ -24,7 +24,7 @@
       });
     </script>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <script>
       (function() {
         var t = localStorage.getItem('zine-theme') || 'light';
@@ -32,7 +32,7 @@
       })();
     </script>
     <style>
-      html, body { background-color: #ede6d8; }
+      html, body { background-color: #f1ead9; }
       html[data-theme="dark"], html[data-theme="dark"] body { background-color: #1a1512; }
     </style>
 </head>
@@ -41,6 +41,26 @@
 
     <div class="app-shell max-w-[1800px] mx-auto px-4 py-4 sm:px-6 sm:py-5">
 
+        <header class="app-header flex items-center justify-between gap-4">
+            <div class="app-brand flex items-center gap-3">
+                <span class="app-brand-mark" aria-hidden="true">
+                    <span class="material-symbols-outlined">menu_book</span>
+                </span>
+                <div class="app-brand-copy">
+                    <h1 class="app-title">Zine-ify</h1>
+                    <p class="app-tagline">Fold one sheet into an 8-page zine</p>
+                </div>
+            </div>
+            <div class="app-header-actions flex items-center gap-2">
+                <button id="pwa-install-trigger" type="button" class="theme-toggle-btn" aria-label="Install app" title="Install app" hidden>
+                    <span class="material-symbols-outlined" style="font-size:18px;" aria-hidden="true">install_mobile</span>
+                </button>
+                <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle dark mode" title="Toggle dark mode">
+                    <span class="material-symbols-outlined" style="font-size:18px;" id="theme-icon">dark_mode</span>
+                </button>
+            </div>
+        </header>
+
         <main class="app-layout grid grid-cols-1 lg:grid-cols-[320px_minmax(0,1fr)] gap-4 sm:gap-5 items-start">
             <!-- Left Column: Sheet Settings -->
             <div id="mobile-rail-overlay" class="mobile-rail-overlay hidden lg:hidden" aria-hidden="true"></div>
@@ -48,13 +68,8 @@
 
                 <div class="control-scroll overflow-y-visible lg:overflow-y-auto space-y-3 lg:pr-1 flex-1 pb-6 lg:pb-10">
                     <section id="settings-group" class="base-panel rail-section rail-settings-panel space-y-3">
-                        <div class="rail-section-header justify-end">
-                            <button id="pwa-install-trigger" type="button" class="theme-toggle-btn" aria-label="Install app" title="Install app" hidden>
-                                <span class="material-symbols-outlined" style="font-size:17px;" aria-hidden="true">install_mobile</span>
-                            </button>
-                            <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle dark mode" title="Toggle dark mode">
-                                <span class="material-symbols-outlined" style="font-size:17px;" id="theme-icon">dark_mode</span>
-                            </button>
+                        <div class="rail-section-header">
+                            <h2 class="rail-section-title">Sheet settings</h2>
                             <button id="close-rail-sheet-btn" type="button" class="rail-sheet-close lg:hidden" aria-label="Close panel">
                                 <span class="material-symbols-outlined text-[16px]" aria-hidden="true">close</span>
                             </button>

--- a/index.html
+++ b/index.html
@@ -93,6 +93,17 @@
                         </details>
                     </section>
 
+                    <section class="base-panel rail-section space-y-2.5">
+                        <h3 class="rail-section-title">Add pages</h3>
+                        <div id="upload-zone" class="upload-box flex flex-col items-center justify-center gap-1.5 text-center p-4 cursor-pointer" role="button" tabindex="0" aria-label="Add pages — click to browse, or drop PDF and image files here">
+                            <span class="material-symbols-outlined" style="font-size:26px; color: var(--primary-vibrant);" aria-hidden="true">upload_file</span>
+                            <span class="text-sm font-semibold">Drop files or click to browse</span>
+                            <span class="text-xs text-zinc-500">PDF, PNG, JPG, or WEBP</span>
+                        </div>
+                        <input type="file" id="pdf-upload" class="sr-only" accept="application/pdf,image/png,image/jpeg,image/webp" multiple aria-hidden="true" tabindex="-1" />
+                        <p id="upload-status" class="upload-status text-xs text-zinc-500" aria-live="polite"></p>
+                    </section>
+
                     <section id="uploaded-files-list" class="hidden">
                         <!-- Populated by JS -->
                     </section>

--- a/src/components/UI/DragAndDropHandler.js
+++ b/src/components/UI/DragAndDropHandler.js
@@ -70,6 +70,14 @@ export class DragAndDropHandler {
 
   handleDragOver(e, cell) {
     if (e.preventDefault) { e.preventDefault(); }
+
+    // External file drag (no internal page is being dragged): allow dropping files onto the cell.
+    if (!this._draggedItem) {
+      if (e.dataTransfer) { e.dataTransfer.dropEffect = 'copy'; }
+      cell.classList.add('drag-over');
+      return false;
+    }
+
     if (this._draggedItem === cell) { return; }
 
     if (!cell.classList.contains('drag-over')) {
@@ -87,10 +95,20 @@ export class DragAndDropHandler {
 
   handleDrop(e, cell) {
     if (e.stopPropagation) { e.stopPropagation(); }
+    if (e.preventDefault) { e.preventDefault(); }
     cell.classList.remove('drag-over');
     this._removePreview(cell);
 
-    if (this._draggedItem && this._draggedItem !== cell) {
+    // External file drop onto a cell — route to the normal import flow.
+    if (!this._draggedItem) {
+      const files = e.dataTransfer ? Array.from(e.dataTransfer.files) : [];
+      if (files.length > 0) {
+        this.emitter.emit('filesDropped', files);
+      }
+      return false;
+    }
+
+    if (this._draggedItem !== cell) {
       const fromIndex = parseInt(this._draggedItem.getAttribute('data-page-index'));
       const toIndex = parseInt(cell.getAttribute('data-page-index'));
       this.emitter.emit('pagesSwapped', { fromIndex, toIndex });

--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -146,9 +146,11 @@ export class UIManager {
       icon.textContent = 'description';
       icon.setAttribute('aria-hidden', 'true');
       const body = document.createElement('div');
+      body.className = 'uploaded-file-body';
       const name = document.createElement('div');
       name.className = 'uploaded-file-name';
       name.textContent = file.name;
+      name.title = file.name;
       const meta = document.createElement('div');
       meta.className = 'uploaded-file-meta';
       meta.textContent = `${file.kind === 'pdf' ? 'PDF' : 'Image'} \u2022 ${file.size ? (file.size / 1024).toFixed(1) + ' KB' : ''}`;

--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -382,6 +382,8 @@ export class UIManager {
 
     this.elements = {
       unifiedDropZone: $('#unified-drop-zone'),
+      uploadZone: $('#upload-zone'),
+      uploadStatus: $('#upload-status'),
       uploadedFilesList: $('#uploaded-files-list'),
       previewArea: $('#preview-area'),
       zineSheetsContainer: $('#zine-sheets-container'),

--- a/src/core/pwa.js
+++ b/src/core/pwa.js
@@ -24,7 +24,9 @@ function wireInstallTrigger() {
   if (!trigger) {return;}
 
   trigger.addEventListener('click', () => {
-    getPwaInstallElement()?.showDialog();
+    // Force the dialog open (true) so it always appears, even when the browser
+    // hasn't fired a native beforeinstallprompt (e.g. desktop, iOS, or repeat visits).
+    getPwaInstallElement()?.showDialog(true);
   });
 }
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -2,24 +2,49 @@
 
 .upload-box {
   border: 1.5px dashed var(--border-color);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-button);
   background-color: var(--surface-muted);
-  min-height: 9rem;
-  transition: border-color 0.2s ease, background-color 0.2s ease;
+  min-height: 8.5rem;
+  color: var(--accent-dark);
+  transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
-.upload-box:hover, .upload-box:focus {
+.upload-box:hover, .upload-box:focus, .upload-box:focus-visible {
   border-color: var(--primary-vibrant);
   background-color: var(--primary-glow);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--primary-glow);
 }
 .upload-box.dragover {
   border-color: var(--primary-vibrant);
   background-color: var(--primary-glow);
+  box-shadow: 0 0 0 3px var(--primary-glow);
 }
 
-.upload-status,
 .grid-total-chip,
 .workspace-description {
   @apply base-chip;
+}
+
+/* Upload status: wrapping caption, never a single-line pill */
+.upload-status {
+  display: block;
+  margin: 0;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  color: var(--muted-ink);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.upload-status:empty {
+  display: none;
+}
+.upload-status[data-tone="error"] {
+  color: var(--primary-deep);
+  font-weight: 600;
+}
+.upload-status[data-tone="success"] {
+  color: var(--accent-dark);
+  font-weight: 600;
 }
 
 .workspace-config-stack { display: grid; gap: 0.65rem; }
@@ -41,16 +66,29 @@
   box-shadow: var(--shadow-sm);
   transform: translateY(-1px);
 }
+.uploaded-file-body {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: grid;
+  gap: 0.15rem;
+}
 .uploaded-file-name {
   font-size: 0.78rem;
   font-weight: 600;
   color: var(--accent-dark);
-  line-height: 1.2;
+  line-height: 1.25;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 .uploaded-file-meta {
   font-size: 0.68rem;
   color: var(--muted-ink);
   line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .uploaded-file-remove {
   width: 1.6rem;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -10,6 +10,43 @@
 .app-layout { min-height: 0; }
 .control-rail { min-height: 0; }
 
+/* ── App header / wordmark ─────────────────────────── */
+.app-header {
+  margin-bottom: 1rem;
+}
+
+.app-brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.85rem;
+  background: var(--primary-vibrant);
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+  flex-shrink: 0;
+}
+.app-brand-mark .material-symbols-outlined {
+  font-size: 1.4rem;
+}
+
+.app-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: clamp(1.5rem, 4vw, 2.1rem);
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--accent-dark);
+}
+
+.app-tagline {
+  margin-top: 0.15rem;
+  font-size: 0.78rem;
+  color: var(--muted-ink);
+  line-height: 1.3;
+}
+
 .control-scroll {
   display: grid;
   align-content: start;
@@ -109,12 +146,21 @@
 .workspace-action-button {
   min-height: 3rem;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
-  background: var(--accent-dark);
-  color: var(--surface-bg);
+  gap: 0.4rem;
+  font-weight: 600;
+  border-radius: var(--radius-button);
+  background: var(--primary-vibrant);
+  color: #fff;
+  transition: filter 0.15s ease, transform 0.1s ease;
+}
+.workspace-action-button:not(:disabled):hover {
+  filter: brightness(0.96);
+}
+.workspace-action-button:not(:disabled):active {
+  transform: translateY(1px);
 }
 
 .workspace-action-button .material-symbols-outlined {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -2,40 +2,43 @@
 
 :root {
   /* Warm studio / newsprint palette */
-  --bg-warm-highlight: #f8f3ea;
-  --bg-warm-shadow: #e3d9c8;
-  --bg-neutral: #ede6d8;
+  --bg-warm-highlight: #fbf5e9;
+  --bg-warm-shadow: #e7ddca;
+  --bg-neutral: #f1ead9;
 
-  --surface-bg: #faf6ef;
-  --surface-strong: #fffdf8;
-  --surface-muted: #f3ece1;
-  --glass-bg-alt: rgba(250, 246, 239, 0.88);
+  --surface-bg: #fcf9f2;
+  --surface-strong: #ffffff;
+  --surface-muted: #f2ebdd;
+  --glass-bg-alt: rgba(252, 249, 242, 0.9);
 
   --surface-paper-stack:
     var(--texture-fiber, none),
-    linear-gradient(165deg, rgba(255, 253, 248, 0.97) 0%, rgba(245, 238, 226, 0.98) 100%);
+    linear-gradient(165deg, rgba(255, 255, 255, 0.96) 0%, rgba(247, 240, 228, 0.98) 100%);
 
-  --accent-dark: #3d3428;
-  --accent-ink-soft: #5c5246;
-  --primary-vibrant: #c45d3e;
-  --primary-deep: #9e4529;
-  --primary-glow: rgba(196, 93, 62, 0.14);
-  --border-color: rgba(61, 52, 40, 0.14);
-  --border-faint: rgba(61, 52, 40, 0.08);
-  --muted-ink: #6f6558;
-  --paper-bg: #fffdf8;
+  --accent-dark: #2c241d;
+  --accent-ink-soft: #574d42;
+  --primary-vibrant: #c0512f;
+  --primary-deep: #95401f;
+  --primary-glow: rgba(192, 81, 47, 0.12);
+  --border-color: rgba(44, 36, 29, 0.14);
+  --border-faint: rgba(44, 36, 29, 0.07);
+  --muted-ink: #756a5b;
+  --paper-bg: #ffffff;
 
-  --shadow-sm: 0 1px 2px rgba(61, 40, 24, 0.06), 0 2px 6px rgba(61, 40, 24, 0.04);
+  --shadow-sm: 0 1px 2px rgba(61, 40, 24, 0.05), 0 2px 6px rgba(61, 40, 24, 0.04);
   --shadow-md: 0 3px 10px rgba(61, 40, 24, 0.08), 0 1px 3px rgba(61, 40, 24, 0.05);
-  --shadow-lg: 0 10px 28px rgba(61, 40, 24, 0.12), 0 3px 8px rgba(61, 40, 24, 0.06);
-  --shadow-paper: 0 1px 0 rgba(255, 255, 255, 0.65) inset, 0 12px 32px rgba(61, 40, 24, 0.1);
+  --shadow-lg: 0 12px 30px rgba(61, 40, 24, 0.13), 0 3px 8px rgba(61, 40, 24, 0.06);
+  --shadow-paper: 0 1px 0 rgba(255, 255, 255, 0.7) inset, 0 12px 32px rgba(61, 40, 24, 0.1);
   --surface-shadow-strong: var(--shadow-paper);
 
-  --radius-panel: 0.875rem;
-  --radius-button: 0.625rem;
+  --font-display: 'Fraunces', 'Iowan Old Style', Georgia, 'Times New Roman', serif;
+  --font-mono-label: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
+
+  --radius-panel: 1rem;
+  --radius-button: 0.7rem;
   --radius-pill: 999px;
-  --border-bold: 1px solid rgba(61, 52, 40, 0.16);
-  --border-thin: 1px solid rgba(61, 52, 40, 0.1);
+  --border-bold: 1px solid rgba(44, 36, 29, 0.16);
+  --border-thin: 1px solid rgba(44, 36, 29, 0.1);
 }
 
 /* ── Dark mode: lamp-lit desk, not cold blue UI ─────────────────────────── */
@@ -115,4 +118,12 @@ body {
 .mobile-zine-app {
   -webkit-tap-highlight-color: transparent;
   min-height: 100vh;
+}
+
+/* Editorial serif for display headings */
+.simulation-modal-header h3,
+#progress-text {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }


### PR DESCRIPTION
- Added a new file upload section with improved drag-and-drop logic for better file handling.
- Integrated a new application header featuring branding elements and UI toggles.
- Updated the global theme color palette to align with refreshed brand guidelines.

[v0 Session](https://v0.app/guitarbeat/chat/vVgPQpfOuZX)

## Summary by Sourcery

Refresh branding, layout, and upload experience for the zine app.

New Features:
- Add a branded app header with wordmark, tagline, and install/dark-mode controls.
- Introduce a dedicated file upload section that supports both click-to-browse and drag-and-drop for PDFs and images, plus cell-level external file drops.

Enhancements:
- Update the global warm palette, shadows, radii, and typography variables to align with the new brand styling, including editorial display fonts for headings.
- Improve upload status messaging, file list layout, and truncation behavior for long filenames and metadata.
- Refine the primary action button styling and app background colors for a more polished UI.
- Adjust the PWA install dialog trigger to always open the dialog when clicked, regardless of native install prompt state.

Build:
- Update theme-color meta tag to match the new primary brand color.