### PR TITLE
🎨 Palette: Add localized loading state to export button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-14 - Icon-only modal close buttons missing ARIA labels
 **Learning:** Icon-only modal close buttons (like the 3D preview and page picker close buttons) often miss `aria-label` and `title` attributes, making them inaccessible to screen readers and lacking tooltips for mouse users. Even dynamically generated modals (like the zoom preview modal in `ModalManager.js`) need these attributes explicitly defined in their HTML template strings.
 **Action:** Always ensure that icon-only interactive elements (`<button>`, `<a>`) have clear, descriptive `aria-label` and `title` attributes, regardless of whether they are hardcoded in the main HTML file or generated dynamically via JavaScript.
+
+## 2024-06-20 - Global progress modal isn't enough context for long actions
+**Learning:** While global progress modals are helpful for overall async operations, relying solely on them without updating the state of the trigger element can lead to confusion and lack of immediate feedback on where the action originated from.
+**Action:** When working on long-running async tasks like PDF generation or file imports, provide localized loading states directly on the trigger element (e.g. `aria-busy="true"`, `disabled`, and inline text/spinners) so screen readers and users immediately know the specific interaction has started processing.

--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -258,13 +258,34 @@ export class UIManager {
     files.forEach((file) => this.emitter.emit('fileSelected', file));
   }
 
+  setExportLoading(isLoading) {
+    if (!this.elements.exportPdfBtn) { return; }
+
+    if (isLoading) {
+      this.elements.exportPdfBtn.setAttribute('aria-busy', 'true');
+      this.elements.exportPdfBtn.disabled = true;
+      this.elements.exportPdfBtn.innerHTML = `
+            <span class="material-symbols-outlined animate-spin" aria-hidden="true">sync</span>
+            <span class="text-sm font-semibold">Exporting...</span>
+        `;
+    } else {
+      this.elements.exportPdfBtn.removeAttribute('aria-busy');
+      this.elements.exportPdfBtn.innerHTML = `
+            <span class="material-symbols-outlined" aria-hidden="true">print</span>
+            <span class="text-sm font-semibold">Export PDF</span>
+        `;
+      // disabled state will be updated by a subsequent call to updateWorkspaceState
+    }
+  }
+
   updateWorkspaceState({ placedCount = 0 } = {}) {
     const hasPagesLoaded = placedCount > 0;
     if (this.elements.clearAllBtn) {
       this.elements.clearAllBtn.style.display = hasPagesLoaded ? '' : 'none';
     }
     if (this.elements.exportPdfBtn) {
-      this.elements.exportPdfBtn.disabled = !hasPagesLoaded;
+      const isExporting = this.elements.exportPdfBtn.getAttribute('aria-busy') === 'true';
+      this.elements.exportPdfBtn.disabled = !hasPagesLoaded || isExporting;
     }
     if (this.elements.view3dBtn) {
       this.elements.view3dBtn.disabled = !hasPagesLoaded;

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -689,6 +689,7 @@ export class AppController {
       return;
     }
 
+    this.ui.setExportLoading(true);
     this.ui.modal.showProgress(true, 'Generating PDF...');
     try {
       await this.exportService.handleExport();
@@ -698,6 +699,8 @@ export class AppController {
     } catch (error) {
       toast.error('Export Failed', error.message);
     } finally {
+      this.ui.setExportLoading(false);
+      this.ui.updateWorkspaceState({ placedCount: this.state.getFilledPageCount() });
       this.ui.modal.showProgress(false);
     }
   }


### PR DESCRIPTION
💡 **What:** Added a localized loading state to the "Export PDF" button. When clicked, it now temporarily disables itself, gains an `aria-busy="true"` attribute, and replaces its icon with a spinning sync icon and "Exporting..." text.
🎯 **Why:** Previously, the user only received feedback via a global progress modal. Adding immediate, localized feedback directly to the button that was clicked improves context and prevents duplicate submissions while the modal is spinning up.
📸 **Before/After:** No major layout changes; the button simply shows a spinner while the PDF generates.
♿ **Accessibility:** Added `aria-busy="true"` so screen readers are aware the specific region/button is actively processing. Ensures `aria-hidden="true"` is preserved on decorative icons.

---
*PR created automatically by Jules for task [13562719456288853573](https://jules.google.com/task/13562719456288853573) started by @guitarbeat*

## Summary by Sourcery

Add a localized loading state and accessibility improvements to the Export PDF button during PDF generation.

Enhancements:
- Introduce a dedicated UIManager helper to toggle the Export PDF button into a loading state with spinner, text, and aria-busy handling.
- Ensure workspace state updates respect the export-in-progress state to keep the Export PDF button disabled while a PDF export is running.

Documentation:
- Document the UX learning about providing localized loading states for long-running actions in the palette journal.