### PR TITLE
🎨 Palette: Add explicit ARIA labels to Page Picker grid and chips

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-14 - Icon-only modal close buttons missing ARIA labels
 **Learning:** Icon-only modal close buttons (like the 3D preview and page picker close buttons) often miss `aria-label` and `title` attributes, making them inaccessible to screen readers and lacking tooltips for mouse users. Even dynamically generated modals (like the zoom preview modal in `ModalManager.js`) need these attributes explicitly defined in their HTML template strings.
 **Action:** Always ensure that icon-only interactive elements (`<button>`, `<a>`) have clear, descriptive `aria-label` and `title` attributes, regardless of whether they are hardcoded in the main HTML file or generated dynamically via JavaScript.
+
+## 2024-06-22 - Missing ARIA labels on visual interactive grids and preset chips
+**Learning:** Internal text or image alt-text is insufficient for robust screen reader navigation on visual interactive grids and preset constraint chips (like the Page Picker preset chips and thumbnails). These interactive elements often require explicitly defined action-oriented `aria-label` attributes to ensure clarity and full screen reader accessibility.
+**Action:** When building visual interactive grids or preset constraint chips in the UI (e.g., in `PagePicker.js` or `index.html`), always explicitly define action-oriented `aria-label` and `title` attributes, regardless of whether they have visible internal text or image alt-text.

--- a/index.html
+++ b/index.html
@@ -386,11 +386,11 @@
 
             <div class="page-picker-toolbar px-5 py-3 border-b border-zinc-100 flex flex-col gap-2.5">
                 <div class="page-picker-presets flex flex-wrap items-center gap-1.5">
-                    <button id="page-picker-select-first" type="button" class="page-picker-chip">First 8</button>
-                    <button id="page-picker-select-last" type="button" class="page-picker-chip">Last 8</button>
-                    <button id="page-picker-select-even" type="button" class="page-picker-chip">Even</button>
-                    <button id="page-picker-select-odd" type="button" class="page-picker-chip">Odd</button>
-                    <button id="page-picker-clear" type="button" class="page-picker-chip">Clear</button>
+                    <button id="page-picker-select-first" type="button" class="page-picker-chip" aria-label="Select the first 8 pages" title="Select the first 8 pages">First 8</button>
+                    <button id="page-picker-select-last" type="button" class="page-picker-chip" aria-label="Select the last 8 pages" title="Select the last 8 pages">Last 8</button>
+                    <button id="page-picker-select-even" type="button" class="page-picker-chip" aria-label="Select even numbered pages" title="Select even numbered pages">Even</button>
+                    <button id="page-picker-select-odd" type="button" class="page-picker-chip" aria-label="Select odd numbered pages" title="Select odd numbered pages">Odd</button>
+                    <button id="page-picker-clear" type="button" class="page-picker-chip" aria-label="Clear page selection" title="Clear page selection">Clear</button>
                 </div>
                 <div class="page-picker-status flex flex-wrap items-center justify-between gap-2">
                     <p id="page-picker-count" class="text-xs font-semibold text-zinc-500 uppercase tracking-wide">

--- a/src/components/UI/PagePicker.js
+++ b/src/components/UI/PagePicker.js
@@ -70,7 +70,7 @@ export class PagePicker {
   }
 
   close(selectedPages = null) {
-    if (!this.state) return;
+    if (!this.state) {return;}
     const { resolve } = this.state;
     this.state = null;
     this.elements.pagePickerModal?.classList.add('hidden');
@@ -81,7 +81,7 @@ export class PagePicker {
   }
 
   confirm() {
-    if (!this.state) return;
+    if (!this.state) {return;}
     const selectedPages = Array.from(this.state.selected).sort((a, b) => a - b);
     if (selectedPages.length === 0) {
       toast.warning('No Pages Selected', 'Choose at least one page to import.');
@@ -92,7 +92,7 @@ export class PagePicker {
 
   _renderGrid(thumbnails, initialSelection = []) {
     const grid = this.elements.pagePickerGrid;
-    if (!grid) return;
+    if (!grid) {return;}
     grid.innerHTML = '';
     thumbnails.forEach(({ pageNumber, thumbnailUrl }) => {
       const btn = document.createElement('button');
@@ -100,6 +100,8 @@ export class PagePicker {
       btn.className = 'page-picker-thumb';
       btn.dataset.pageNumber = String(pageNumber);
       btn.setAttribute('aria-pressed', initialSelection.includes(pageNumber) ? 'true' : 'false');
+      btn.setAttribute('aria-label', `Toggle page ${pageNumber} selection`);
+      btn.title = `Toggle page ${pageNumber} selection`;
 
       const media = document.createElement('div');
       media.className = 'page-picker-thumb-media';
@@ -126,7 +128,7 @@ export class PagePicker {
   }
 
   _toggle(pageNumber) {
-    if (!this.state) return;
+    if (!this.state) {return;}
     const { selected, selectionLimit } = this.state;
     if (selected.has(pageNumber)) {
       selected.delete(pageNumber);
@@ -141,7 +143,7 @@ export class PagePicker {
   }
 
   applyPreset(preset) {
-    if (!this.state) return;
+    if (!this.state) {return;}
     const { thumbnails, selectionLimit, selected } = this.state;
     selected.clear();
     let next = [];
@@ -159,7 +161,7 @@ export class PagePicker {
   }
 
   _updateStatus() {
-    if (!this.state) return;
+    if (!this.state) {return;}
     const selectedPages = Array.from(this.state.selected).sort((a, b) => a - b);
     const orderMap = new Map(selectedPages.map((n, i) => [n, i + 1]));
     const hasCapacity = selectedPages.length < this.state.selectionLimit;
@@ -171,7 +173,7 @@ export class PagePicker {
       btn.classList.toggle('is-selected', isSelected);
       btn.classList.toggle('is-disabled', !isSelected && !hasCapacity);
       btn.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
-      if (order) order.textContent = isSelected ? String(orderMap.get(pageNum)) : '';
+      if (order) {order.textContent = isSelected ? String(orderMap.get(pageNum)) : '';}
     });
 
     if (this.elements.pagePickerCount) {


### PR DESCRIPTION
### 💡 What
Added action-oriented `aria-label` and `title` attributes to the visual interactive preset chips and thumbnail buttons within the Page Picker modal.

### 🎯 Why
Visual grids and chips often rely on visible text or image content to imply action. However, for screen reader users and users navigating via keyboard, explicitly defining the interactive purpose (e.g., "Toggle page 1 selection" instead of just "Page 1") significantly improves the accessibility and clarity of the interaction.

### 📸 Before/After
_No visual changes to the UI styling. Tooltips now appear on hover for the preset chips and thumbnails._

### ♿ Accessibility
*   **Screen Readers:** The preset chips and individual page thumbnails now have explicit, action-oriented labels, allowing assistive technologies to announce exactly what interaction will happen.
*   **Mouse/Pointer:** Added `title` attributes that mirror the `aria-label`s to provide helpful native tooltips on hover.

---
*PR created automatically by Jules for task [4557500327648319109](https://jules.google.com/task/4557500327648319109) started by @guitarbeat*

## Summary by Sourcery

Improve accessibility of the Page Picker modal by adding explicit action-oriented labels to grid thumbnails and preset chips.

New Features:
- Add descriptive aria-label and title attributes to Page Picker preset chips in the toolbar.
- Add action-oriented aria-label and title attributes to Page Picker thumbnail buttons in the grid.

Enhancements:
- Document accessibility learnings and guidelines for ARIA labels on visual interactive grids and preset chips in the Palette notes.