### PR TITLE
🎨 Palette: Add localized loading state to Export PDF button

### DIFF
--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -84,8 +84,6 @@ export class UIManager {
 
     let lastGridState = { rows: DEFAULT_GRID_ROWS, cols: DEFAULT_GRID_COLS };
 
-    let lastGridState = { rows: DEFAULT_GRID_ROWS, cols: DEFAULT_GRID_COLS };
-
     this.smartSheetConfig = new SmartSheetConfig(container, {
       initialRows: DEFAULT_GRID_ROWS,
       initialCols: DEFAULT_GRID_COLS,

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -696,6 +696,14 @@ export class AppController {
       return;
     }
 
+    const exportBtn = this.ui.elements.exportPdfBtn;
+    const originalContent = exportBtn ? exportBtn.innerHTML : '';
+    if (exportBtn) {
+      exportBtn.disabled = true;
+      exportBtn.setAttribute('aria-busy', 'true');
+      exportBtn.innerHTML = '<span class="material-symbols-outlined animate-spin" aria-hidden="true">progress_activity</span><span class="text-sm font-semibold">Exporting...</span>';
+    }
+
     this.ui.modal.showProgress(true, 'Generating PDF...');
     try {
       await this.exportService.handleExport();
@@ -706,6 +714,11 @@ export class AppController {
       toast.error('Export Failed', error.message);
     } finally {
       this.ui.modal.showProgress(false);
+      if (exportBtn) {
+        exportBtn.disabled = false;
+        exportBtn.removeAttribute('aria-busy');
+        exportBtn.innerHTML = originalContent;
+      }
     }
   }
 }


### PR DESCRIPTION
💡 **What:** Adds a localized loading state directly to the "Export PDF" button when the async export operation runs. 
🎯 **Why:** To improve contextual feedback for long-running tasks as per standard interaction design patterns, avoiding reliance entirely on global overlay modals and giving immediate validation to the button press.
♿ **Accessibility:** Replaces standard `disabled` with a combination of `disabled` and `aria-busy="true"` on the button during processing, aligning with standard W3C async interaction guidelines.

---
*PR created automatically by Jules for task [2579737792080659082](https://jules.google.com/task/2579737792080659082) started by @guitarbeat*

## Summary by Sourcery

Add a contextual loading state to the Export PDF action and clean up redundant UI state initialization.

New Features:
- Show an in-button loading state for the Export PDF action while the async export is running.

Enhancements:
- Disable the Export PDF button and mark it aria-busy during export, restoring its original content and state afterward.
- Remove redundant initialization of the grid state in the UI manager.