### PR TITLE
fix(ui): implement dark mode theme toggle functionality

### DIFF
--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -70,6 +70,7 @@ export class UIManager {
     this.syncPaperSettings({ paperSize: 'letter', orientation: 'landscape' });
     this.setupEventListeners();
     this.syncResponsiveUI();
+    this._syncThemeIcon();
 
     const savedControls = localStorage.getItem('zine-page-controls');
     const showControls = savedControls !== 'false';
@@ -434,7 +435,9 @@ export class UIManager {
       bookletStatus: $('#booklet-status'),
       clearAllBtn: $('#clear-all-btn'),
       exportPdfBtn: $('#exportPdfBtn'),
-      view3dBtn: $('#view3dBtn')
+      view3dBtn: $('#view3dBtn'),
+      themeToggleBtn: $('#theme-toggle'),
+      themeIcon: $('#theme-icon')
     };
   }
 
@@ -498,6 +501,7 @@ export class UIManager {
     this.elements.exportPdfBtn?.addEventListener('click', () => this.emitter.emit('export'));
     this.elements.view3dBtn?.addEventListener('click', () => this.emitter.emit('view3d'));
     this.elements.clearAllBtn?.addEventListener('click', () => this.emitter.emit('clearAll'));
+    this.elements.themeToggleBtn?.addEventListener('click', () => this.toggleTheme());
 
     this.elements.uploadZone?.addEventListener('click', () => this.triggerFileUpload());
     this.elements.uploadZone?.addEventListener('keydown', (event) => {
@@ -572,6 +576,21 @@ export class UIManager {
     }
 
     window.addEventListener('resize', () => this.syncResponsiveUI());
+  }
+
+  toggleTheme() {
+    const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', newTheme);
+    localStorage.setItem('zine-theme', newTheme);
+    this._syncThemeIcon();
+  }
+
+  _syncThemeIcon() {
+    if (this.elements.themeIcon) {
+      const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+      this.elements.themeIcon.textContent = currentTheme === 'light' ? 'light_mode' : 'dark_mode';
+    }
   }
 
   isFoldPreviewOpen() {

--- a/src/utils/gridStack.js
+++ b/src/utils/gridStack.js
@@ -30,7 +30,7 @@ function storageKey() {
 }
 
 function nodesOverlap(a, b) {
-  if (a.id === b.id) return false;
+  if (a.id === b.id) { return false; }
   return !(
     a.x + a.w <= b.x ||
     b.x + b.w <= a.x ||
@@ -43,26 +43,26 @@ function layoutHasOverlaps() {
   const nodes = grid?.engine?.nodes ?? [];
   for (let i = 0; i < nodes.length; i++) {
     for (let j = i + 1; j < nodes.length; j++) {
-      if (nodesOverlap(nodes[i], nodes[j])) return true;
+      if (nodesOverlap(nodes[i], nodes[j])) { return true; }
     }
   }
   return false;
 }
 
 function saveLayout() {
-  if (!grid || isRelayouting) return;
+  if (!grid || isRelayouting) { return; }
   try {
     localStorage.setItem(storageKey(), JSON.stringify(grid.save(false)));
-  } catch (_) {}
+  } catch (_e) { void _e; }
 }
 
 function compactLayout() {
-  if (!grid) return;
+  if (!grid) { return; }
   grid.compact('list');
 }
 
 function relayoutPanels() {
-  if (!grid) return;
+  if (!grid) { return; }
   isRelayouting = true;
 
   grid.getGridItems().forEach((el) => grid.resizeToContent(el));
@@ -72,22 +72,22 @@ function relayoutPanels() {
 }
 
 function resetToDefaults() {
-  if (!grid) return;
+  if (!grid) { return; }
   localStorage.removeItem(storageKey());
 
   grid.batchUpdate(true);
   DEFAULT_LAYOUT.forEach(({ id, x, y, w, h }) => {
     const el = gridEl.querySelector(`[gs-id="${id}"]`);
-    if (el) grid.update(el, { x, y, w, h });
+    if (el) { grid.update(el, { x, y, w, h }); }
   });
   grid.batchUpdate(false);
 
-  if (isMobile()) compactLayout();
+  if (isMobile()) { compactLayout(); }
   relayoutPanels();
 }
 
 function loadLayout() {
-  if (!grid) return;
+  if (!grid) { return; }
 
   try {
     const raw = localStorage.getItem(storageKey());
@@ -108,22 +108,23 @@ function loadLayout() {
     if (layoutHasOverlaps()) {
       resetToDefaults();
     }
-  } catch (_) {
+  } catch (_e) {
+    void _e;
     resetToDefaults();
   }
 }
 
 function scheduleRelayout() {
-  if (resizeFrame) cancelAnimationFrame(resizeFrame);
+  if (resizeFrame) { cancelAnimationFrame(resizeFrame); }
   resizeFrame = requestAnimationFrame(() => {
     relayoutPanels();
-    if (layoutHasOverlaps()) compactLayout();
+    if (layoutHasOverlaps()) { compactLayout(); }
     resizeFrame = null;
   });
 }
 
 function observePanelSizes() {
-  if (resizeObserver) resizeObserver.disconnect();
+  if (resizeObserver) { resizeObserver.disconnect(); }
 
   resizeObserver = new ResizeObserver(() => scheduleRelayout());
 
@@ -133,14 +134,14 @@ function observePanelSizes() {
 }
 
 function syncGridMetrics() {
-  if (!grid) return;
+  if (!grid) { return; }
   grid.cellHeight(CELL_HEIGHT);
   grid.margin(isMobile() ? 6 : 8);
   grid.float(false);
 }
 
 function setInteractionMode() {
-  if (!grid) return;
+  if (!grid) { return; }
   const mobile = isMobile();
   document.body.classList.toggle('layout-mobile', mobile);
   syncGridMetrics();
@@ -151,7 +152,7 @@ function setInteractionMode() {
 
 export function initGridStack() {
   gridEl = document.querySelector('.grid-stack');
-  if (!gridEl) return;
+  if (!gridEl) { return; }
 
   grid = GridStack.init({
     column: 12,


### PR DESCRIPTION
The 'night toggle' button had the necessary DOM elements but lacked the Javascript logic to change the state.
Added the 'toggleTheme' logic inside 'UIManager' which updates the DOM 'data-theme' attribute and 'localStorage' to ensure the theme sticks, and updates the toggle icon appropriately.

---
*PR created automatically by Jules for task [9122090252482719419](https://jules.google.com/task/9122090252482719419) started by @guitarbeat*

## Summary by Sourcery

Add theme toggle support to the UI manager so users can switch between light and dark modes and persist their choice.

New Features:
- Introduce a theme toggle button in the UI that switches between light and dark themes.
- Persist the selected theme in localStorage so it is restored on subsequent visits.

Enhancements:
- Synchronize the theme icon with the current theme on initialization and after theme changes.