### PR TITLE
Split Preview Fold modal into draggable panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,12 +193,12 @@
                     </div>
                 </div>
 
-                <!-- ── PANEL: Preview fold ───────────────────────────── -->
+                <!-- ── PANEL: Preview fold (trigger) ────────────────────── -->
                 <div class="grid-stack-item"
-                    gs-id="preview-fold" gs-x="4" gs-y="10" gs-w="4" gs-h="2"
+                    gs-id="preview-fold-trigger" gs-x="4" gs-y="10" gs-w="4" gs-h="2"
                     gs-min-w="2" gs-min-h="2" gs-size-to-content="true">
                     <div class="grid-stack-item-content">
-                        <div class="snap-card snap-card--action" id="card-preview-fold">
+                        <div class="snap-card snap-card--action" id="card-preview-fold-trigger">
                             <div class="snap-card-handle" title="Drag to move">
                                 <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
                                 <span class="snap-card-label">Preview fold</span>
@@ -210,6 +210,117 @@
                                     <span class="material-symbols-outlined" aria-hidden="true">view_in_ar</span>
                                     <span class="font-semibold">Preview Fold</span>
                                 </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ── PANEL: 3D Fold Viewer ────────────────────────────── -->
+                <div class="grid-stack-item"
+                    gs-id="fold-viewer" gs-x="0" gs-y="12" gs-w="6" gs-h="6"
+                    gs-min-w="4" gs-min-h="4" gs-size-to-content="true">
+                    <div class="grid-stack-item-content">
+                        <div class="snap-card fold-viewer-card hidden" id="card-fold-viewer">
+                            <div class="snap-card-handle" title="Drag to move">
+                                <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
+                                <span class="snap-card-label">3D Fold Viewer</span>
+                            </div>
+                            <div class="snap-card-body snap-card-body--fold-viewer">
+                                <div class="fold-viewer-header">
+                                    <div>
+                                        <p class="fold-viewer-kicker">Simulation</p>
+                                        <p class="fold-viewer-title">Move from the open sheet to the finished booklet.</p>
+                                    </div>
+                                    <p class="fold-viewer-note">Drag to orbit · slider or step buttons to jump</p>
+                                </div>
+                                <div id="zine-3d-container" class="fold-viewer-stage"></div>
+                                <section class="fold-viewer-controls" aria-label="Fold checkpoints">
+                                    <div class="fold-viewer-control-row">
+                                        <div>
+                                            <p class="fold-viewer-control-kicker">Steps</p>
+                                            <p class="fold-viewer-control-title">Follow the actual fold sequence.</p>
+                                        </div>
+                                        <span id="fold-status" class="simulation-status-chip">Flat</span>
+                                    </div>
+                                    <div class="fold-viewer-slider-row">
+                                        <label for="fold-slider" class="font-semibold text-xs uppercase whitespace-nowrap flex items-center gap-1.5 text-zinc-500">
+                                            <span class="material-symbols-outlined text-[16px]" style="color: var(--primary-vibrant);" aria-hidden="true">animation</span>
+                                            Position
+                                        </label>
+                                        <input type="range" id="fold-slider" min="0" max="3" step="0.01" value="0" class="flex-1 w-full h-1.5 cursor-pointer" style="accent-color: var(--primary-vibrant);">
+                                    </div>
+                                    <p id="fold-helper" class="fold-viewer-helper">Export the layout, crease the sheet in half both ways and open flat, then fold and make one short cut through the center before collapsing into a booklet.</p>
+                                    <div class="fold-viewer-step-grid" aria-label="Fold simulation checkpoints">
+                                        <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="0"   data-step-index="1">1. Layout</button>
+                                        <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="0.5" data-step-index="2">2. Crease</button>
+                                        <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="1"   data-step-index="3">3. Strip</button>
+                                        <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="1.5" data-step-index="4">4. Cut</button>
+                                        <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="2"   data-step-index="5">5. Diamond</button>
+                                        <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="3"   data-step-index="6">6. Booklet</button>
+                                    </div>
+                                </section>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ── PANEL: Booklet Preview ────────────────────────── -->
+                <div class="grid-stack-item"
+                    gs-id="fold-booklet" gs-x="6" gs-y="12" gs-w="3" gs-h="4"
+                    gs-min-w="3" gs-min-h="3" gs-size-to-content="true">
+                    <div class="grid-stack-item-content">
+                        <div class="snap-card fold-booklet-card hidden" id="card-fold-booklet">
+                            <div class="snap-card-handle" title="Drag to move">
+                                <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
+                                <span class="snap-card-label">Booklet Preview</span>
+                            </div>
+                            <div class="snap-card-body snap-card-body--fold-booklet">
+                                <div class="fold-booklet-header">
+                                    <div>
+                                        <p class="fold-booklet-kicker">Booklet</p>
+                                        <p class="fold-booklet-title">Spread preview</p>
+                                    </div>
+                                    <span id="booklet-status" class="simulation-status-chip">Loading</span>
+                                </div>
+                                <div id="booklet-preview-container" class="fold-booklet-preview-container" aria-label="Small booklet preview"></div>
+                                <div class="grid grid-cols-2 gap-2.5">
+                                    <button id="booklet-prev-btn" class="action-button w-full py-2 px-3 flex items-center justify-center gap-1.5 bg-white text-zinc-800 font-medium text-sm" type="button">
+                                        <span class="material-symbols-outlined text-base" aria-hidden="true">chevron_left</span>Prev
+                                    </button>
+                                    <button id="booklet-next-btn" class="action-button w-full py-2 px-3 flex items-center justify-center gap-1.5 bg-zinc-900 text-white font-medium text-sm" type="button">
+                                        Next<span class="material-symbols-outlined text-base" aria-hidden="true">chevron_right</span>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ── PANEL: Fold Guide ────────────────────────────── -->
+                <div class="grid-stack-item"
+                    gs-id="fold-guide" gs-x="9" gs-y="12" gs-w="3" gs-h="4"
+                    gs-min-w="3" gs-min-h="3" gs-size-to-content="true">
+                    <div class="grid-stack-item-content">
+                        <div class="snap-card fold-guide-card hidden" id="card-fold-guide">
+                            <div class="snap-card-handle" title="Drag to move">
+                                <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
+                                <span class="snap-card-label">How to Fold</span>
+                            </div>
+                            <div class="snap-card-body snap-card-body--fold-guide">
+                                <div class="fold-guide-header">
+                                    <p class="fold-guide-kicker">How to fold</p>
+                                    <p class="fold-guide-title">8 pages · 1 sheet · 1 cut</p>
+                                </div>
+                                <ol class="fold-guide-list" aria-label="Folding steps">
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">1</span><span class="fold-guide-text">Design your zine on one sheet, with the pages in this order and orientation.</span></div><img src="/fold-guide/step-0-plan.png" alt="Page layout diagram" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">2</span><span class="fold-guide-text">Crease the sheet along both main directions — fold in half each way, then open flat.</span></div><img src="/fold-guide/step-1-crease.png" alt="Sheet with crease lines" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">3</span><span class="fold-guide-text">Make two more creases to divide the long direction into quarters, then open flat again.</span></div><img src="/fold-guide/step-2-quarters.png" alt="Quarter crease marks" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">4</span><span class="fold-guide-text">Fold in half, then cut along the center crease — only as far as the quarter-fold marks.</span></div><img src="/fold-guide/step-3-cut.png" alt="Center cut" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">5</span><span class="fold-guide-text">Open it out flat. You'll see a short slit through the center.</span></div><img src="/fold-guide/step-4-open.png" alt="Center slit" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">6</span><span class="fold-guide-text">Fold in half along the long direction so all pages stay on the outside.</span></div><img src="/fold-guide/step-5-fold-strip.png" alt="Long strip fold" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">7</span><span class="fold-guide-text">Push inward from both ends — the slit opens into a cross. Bring pages together with cover outermost.</span></div><img src="/fold-guide/step-6-push-in.png" alt="Diamond cross" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">8</span><span class="fold-guide-text">Fold flat and crease. You now have an 8-page booklet.</span></div><img src="/fold-guide/step-7-booklet.png" alt="Finished booklet" class="fold-guide-img" loading="lazy" /></li>
+                                </ol>
                             </div>
                         </div>
                     </div>
@@ -247,106 +358,6 @@
     <!-- ── Toast ────────────────────────────────────────── -->
     <div id="toast-container" class="toast-container fixed bottom-6 right-6 z-[300] space-y-3" aria-live="polite" aria-atomic="true" role="region" aria-label="Notifications"></div>
 
-    <!-- ── 3D Modal ──────────────────────────────────────── -->
-    <div id="zine-3d-modal" class="fixed inset-0 z-[200] hidden flex-col items-center justify-center opacity-0 transition-opacity duration-300 simulation-modal" style="display: none;">
-        <div class="simulation-modal-shell">
-            <div class="simulation-modal-header">
-                <div class="simulation-modal-intro">
-                    <p class="simulation-modal-kicker">Fold preview</p>
-                    <div class="space-y-1">
-                        <h3 class="text-lg font-semibold flex items-center gap-2">
-                            <span class="material-symbols-outlined text-[18px]" style="color: var(--primary-vibrant);" aria-hidden="true">view_in_ar</span>
-                            Preview the fold
-                        </h3>
-                        <p class="simulation-modal-summary">Check the cut, fold sequence, and finished booklet.</p>
-                    </div>
-                    <div class="simulation-modal-meta" aria-label="Simulation legend">
-                        <span class="simulation-meta-chip">Red = cut</span>
-                        <span class="simulation-meta-chip">Gray = fold</span>
-                        <span class="simulation-meta-chip">Keys 1–6 = steps</span>
-                    </div>
-                </div>
-                <button id="close-3d-btn" class="action-button simulation-close-btn bg-white text-zinc-800 font-semibold focus:outline-none" type="button" aria-label="Close 3D preview" title="Close">
-                    <span class="material-symbols-outlined text-lg" aria-hidden="true">close</span>
-                </button>
-            </div>
-            <div class="simulation-modal-body">
-                <section class="simulation-canvas-panel" aria-label="Fold simulation">
-                    <div class="simulation-panel-top">
-                        <div>
-                            <p class="simulation-panel-kicker">Simulation</p>
-                            <p class="simulation-panel-title">Move from the open sheet to the finished booklet.</p>
-                        </div>
-                        <p class="simulation-panel-note">Drag to orbit · slider or step buttons to jump</p>
-                    </div>
-                    <div id="zine-3d-container" class="simulation-canvas-stage"></div>
-                </section>
-                <aside class="simulation-sidebar">
-                    <section class="simulation-panel simulation-fold-panel" aria-label="Fold checkpoints">
-                        <div class="simulation-panel-top">
-                            <div>
-                                <p class="simulation-panel-kicker">Steps</p>
-                                <p class="simulation-panel-title">Follow the actual fold sequence.</p>
-                            </div>
-                            <span id="fold-status" class="simulation-status-chip">Flat</span>
-                        </div>
-                        <div class="simulation-slider-row">
-                            <label for="fold-slider" class="font-semibold text-xs uppercase whitespace-nowrap flex items-center gap-1.5 text-zinc-500">
-                                <span class="material-symbols-outlined text-[16px]" style="color: var(--primary-vibrant);" aria-hidden="true">animation</span>
-                                Position
-                            </label>
-                            <input type="range" id="fold-slider" min="0" max="3" step="0.01" value="0" class="flex-1 w-full h-1.5 cursor-pointer" style="accent-color: var(--primary-vibrant);">
-                        </div>
-                        <p id="fold-helper" class="simulation-helper">Export the layout, crease the sheet in half both ways and open flat, then fold and make one short cut through the center before collapsing into a booklet.</p>
-                        <div class="simulation-step-grid" aria-label="Fold simulation checkpoints">
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="0"   data-step-index="1">1. Layout</button>
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="0.5" data-step-index="2">2. Crease</button>
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="1"   data-step-index="3">3. Strip</button>
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="1.5" data-step-index="4">4. Cut</button>
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="2"   data-step-index="5">5. Diamond</button>
-                            <button type="button" class="fold-step-btn action-button w-full py-2 px-3 bg-white text-zinc-800 font-medium text-sm" data-fold-value="3"   data-step-index="6">6. Booklet</button>
-                        </div>
-                    </section>
-                    <section class="simulation-panel simulation-booklet-panel" aria-label="Booklet preview">
-                        <div class="simulation-panel-top">
-                            <div>
-                                <p class="simulation-panel-kicker">Booklet</p>
-                                <p class="simulation-panel-title">Use Prev / Next to step through each spread in reading order.</p>
-                            </div>
-                            <span id="booklet-status" class="simulation-status-chip">Loading</span>
-                        </div>
-                        <div id="booklet-preview-container" class="booklet-preview-container" aria-label="Small booklet preview"></div>
-                        <div class="grid grid-cols-2 gap-2.5">
-                            <button id="booklet-prev-btn" class="action-button w-full py-2 px-3 flex items-center justify-center gap-1.5 bg-white text-zinc-800 font-medium text-sm" type="button">
-                                <span class="material-symbols-outlined text-base" aria-hidden="true">chevron_left</span>Prev
-                            </button>
-                            <button id="booklet-next-btn" class="action-button w-full py-2 px-3 flex items-center justify-center gap-1.5 bg-zinc-900 text-white font-medium text-sm" type="button">
-                                Next<span class="material-symbols-outlined text-base" aria-hidden="true">chevron_right</span>
-                            </button>
-                        </div>
-                    </section>
-                    <section class="simulation-panel simulation-guide-panel" aria-label="How to fold">
-                        <div class="simulation-panel-top">
-                            <div>
-                                <p class="simulation-panel-kicker">How to fold</p>
-                                <p class="simulation-panel-title">8 pages · 1 sheet · 1 cut</p>
-                            </div>
-                        </div>
-                        <ol class="simulation-fold-guide" aria-label="Folding steps">
-                            <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">1</span><span class="fold-guide-text">Design your zine on one sheet, with the pages in this order and orientation.</span></div><img src="/fold-guide/step-0-plan.png" alt="Page layout diagram" class="fold-guide-img" loading="lazy" /></li>
-                            <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">2</span><span class="fold-guide-text">Crease the sheet along both main directions — fold in half each way, then open flat.</span></div><img src="/fold-guide/step-1-crease.png" alt="Sheet with crease lines" class="fold-guide-img" loading="lazy" /></li>
-                            <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">3</span><span class="fold-guide-text">Make two more creases to divide the long direction into quarters, then open flat again.</span></div><img src="/fold-guide/step-2-quarters.png" alt="Quarter crease marks" class="fold-guide-img" loading="lazy" /></li>
-                            <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">4</span><span class="fold-guide-text">Fold in half, then cut along the center crease — only as far as the quarter-fold marks.</span></div><img src="/fold-guide/step-3-cut.png" alt="Center cut" class="fold-guide-img" loading="lazy" /></li>
-                            <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">5</span><span class="fold-guide-text">Open it out flat. You'll see a short slit through the center.</span></div><img src="/fold-guide/step-4-open.png" alt="Center slit" class="fold-guide-img" loading="lazy" /></li>
-                            <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">6</span><span class="fold-guide-text">Fold in half along the long direction so all pages stay on the outside.</span></div><img src="/fold-guide/step-5-fold-strip.png" alt="Long strip fold" class="fold-guide-img" loading="lazy" /></li>
-                            <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">7</span><span class="fold-guide-text">Push inward from both ends — the slit opens into a cross. Bring pages together with cover outermost.</span></div><img src="/fold-guide/step-6-push-in.png" alt="Diamond cross" class="fold-guide-img" loading="lazy" /></li>
-                            <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">8</span><span class="fold-guide-text">Fold flat and crease. You now have an 8-page booklet.</span></div><img src="/fold-guide/step-7-booklet.png" alt="Finished booklet" class="fold-guide-img" loading="lazy" /></li>
-                        </ol>
-                    </section>
-                </aside>
-            </div>
-        </div>
-    </div>
 
     <!-- ── PWA Install Banner ────────────────────────────── -->
     <zineify-install-banner

--- a/src/components/UI/ModalManager.js
+++ b/src/components/UI/ModalManager.js
@@ -1,4 +1,3 @@
-
 import { PagePicker } from './PagePicker.js';
 import { ProgressOverlay } from './ProgressOverlay.js';
 
@@ -38,22 +37,19 @@ export class ModalManager {
 
   /* ── 3D Modal ── */
   toggle3DModal(show) {
-    const modal = this.elements.zine3dModal;
-    if (!modal) {return;}
+    // Show/hide three fold panels instead of modal
+    const foldViewerCard = document.getElementById('card-fold-viewer');
+    const foldBookletCard = document.getElementById('card-fold-booklet');
+    const foldGuideCard = document.getElementById('card-fold-guide');
+
     if (show) {
-      modal.style.display = 'flex';
-      modal.classList.remove('hidden');
-      requestAnimationFrame(() => {
-        modal.classList.remove('opacity-0');
-        modal.classList.add('opacity-100');
-      });
+      foldViewerCard?.classList.remove('hidden');
+      foldBookletCard?.classList.remove('hidden');
+      foldGuideCard?.classList.remove('hidden');
     } else {
-      modal.classList.add('opacity-0');
-      modal.classList.remove('opacity-100');
-      setTimeout(() => {
-        modal.classList.add('hidden');
-        modal.style.display = 'none';
-      }, 300);
+      foldViewerCard?.classList.add('hidden');
+      foldBookletCard?.classList.add('hidden');
+      foldGuideCard?.classList.add('hidden');
     }
   }
 

--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -510,7 +510,6 @@ export class UIManager {
     this.elements.openRailSheetBtn?.addEventListener('click', () => this.toggleMobileRail(true));
     this.elements.closeRailSheetBtn?.addEventListener('click', () => this.toggleMobileRail(false));
     this.elements.mobileRailOverlay?.addEventListener('click', () => this.toggleMobileRail(false));
-    this.elements.close3dBtn?.addEventListener('click', () => this.toggle3DModal(false));
 
     this.elements.foldSlider?.addEventListener('input', (event) => {
       const value = parseFloat(event.target.value || '0');
@@ -575,9 +574,8 @@ export class UIManager {
   }
 
   isFoldPreviewOpen() {
-    return !!this.elements.zine3dModal
-      && !this.elements.zine3dModal.classList.contains('hidden')
-      && this.elements.zine3dModal.style.display !== 'none';
+    const foldViewerCard = document.getElementById('card-fold-viewer');
+    return foldViewerCard && !foldViewerCard.classList.contains('hidden');
   }
 
   generateLayout(numPages, templateType, paperSettings = {}) {

--- a/src/styles/simulation.css
+++ b/src/styles/simulation.css
@@ -1,36 +1,39 @@
-.simulation-modal {
-  background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-}
-
-.simulation-modal-shell {
-  width: min(100%, 86rem);
-  height: 100%;
-  max-height: 100dvh;
-  padding: 1rem;
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
-  gap: 1rem;
-  overflow: hidden;
-}
-
-.simulation-modal-header {
+/* Panel-specific styles for fold viewer, booklet, and guide */
+.fold-viewer-card,
+.fold-booklet-card,
+.fold-guide-card {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
+  flex-direction: column;
+  height: 100%;
+}
+
+.fold-viewer-card.hidden,
+.fold-booklet-card.hidden,
+.fold-guide-card.hidden {
+  display: none;
+}
+
+.snap-card-body--fold-viewer,
+.snap-card-body--fold-booklet,
+.snap-card-body--fold-guide {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
   min-height: 0;
+  overflow-y: auto;
+}
+
+.fold-viewer-header,
+.fold-booklet-header,
+.fold-guide-header {
+  display: grid;
+  gap: 0.35rem;
   flex-shrink: 0;
 }
 
-.simulation-modal-intro {
-  display: grid;
-  gap: 0.65rem;
-  min-width: 0;
-}
-
-.simulation-modal-kicker,
+.fold-viewer-kicker,
+.fold-booklet-kicker,
+.fold-guide-kicker,
 .simulation-panel-kicker {
   font-size: 0.68rem;
   font-weight: 700;
@@ -39,80 +42,9 @@
   color: var(--muted-ink);
 }
 
-.simulation-modal-summary,
-.simulation-panel-note,
-.simulation-helper {
-  font-size: 0.85rem;
-  line-height: 1.5;
-  color: var(--muted-ink);
-}
-
-.simulation-modal-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-}
-
-.simulation-meta-chip,
-.simulation-status-chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 1.75rem;
-  padding: 0.28rem 0.65rem;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-pill);
-  background: var(--surface-bg);
-  color: var(--accent-dark);
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.simulation-close-btn {
-  flex: 0 0 auto;
-  width: 2.5rem;
-  height: 2.5rem;
-}
-
-.simulation-modal-body {
-  min-height: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 22rem);
-  gap: 1rem;
-  overflow: hidden;
-  overflow-y: auto;
-}
-
-.simulation-canvas-panel,
-.simulation-panel {
-  min-height: 0;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-panel);
-  background: var(--surface-bg);
-  box-shadow: var(--shadow-md);
-  padding: 1rem;
-}
-
-.simulation-canvas-panel {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
-  gap: 0.75rem;
-}
-
-.simulation-panel {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.simulation-panel-top {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.85rem;
-}
-
+.fold-viewer-title,
+.fold-booklet-title,
+.fold-guide-title,
 .simulation-panel-title {
   font-weight: 600;
   line-height: 1.3;
@@ -120,22 +52,15 @@
   color: var(--accent-dark);
 }
 
-.simulation-slider-row {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
-  gap: 0.75rem;
+.fold-viewer-note,
+.simulation-panel-note {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--muted-ink);
 }
 
-.simulation-step-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
-}
-
-.simulation-canvas-stage {
-  min-height: 24rem;
-  height: 100%;
+.fold-viewer-stage {
+  min-height: 16rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-button);
   background:
@@ -154,7 +79,7 @@
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -30px 60px rgba(0,0,0,0.24);
 }
 
-.simulation-canvas-stage::after {
+.fold-viewer-stage::after {
   content: "fold simulation";
   position: absolute;
   left: 0.85rem;
@@ -172,67 +97,98 @@
   pointer-events: none;
 }
 
-.zine-3d-canvas,
-.zine-3d-fallback-canvas {
-  display: block;
-  width: 100%;
-  height: 100%;
-}
-
-.simulation-sidebar {
-  min-height: 0;
+.fold-viewer-controls {
   display: grid;
-  gap: 0.85rem;
-  align-content: start;
-  overflow-y: auto;
-  padding-right: 0.2rem;
-}
-
-.simulation-booklet-panel {
-  position: relative;
-  z-index: 2;
-}
-
-.simulation-guide-panel {
-  position: relative;
-  z-index: 1;
-  overflow: visible;
+  gap: 0.75rem;
   flex-shrink: 0;
 }
 
-/* Compact folding guide - no scrollbars */
-.simulation-fold-guide {
+.fold-viewer-control-row {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.85rem;
+}
+
+.fold-viewer-control-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--accent-dark);
+}
+
+.fold-viewer-slider-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.fold-viewer-step-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.fold-viewer-helper,
+.simulation-panel-note,
+.simulation-helper {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--muted-ink);
+}
+
+.fold-booklet-preview-container {
+  min-height: 11rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    radial-gradient(circle at 50% 10%, rgba(196, 93, 62, 0.1), transparent 35%),
+    linear-gradient(180deg, var(--surface-muted), var(--bg-neutral));
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-button);
+  padding: 1.25rem;
+  overflow: hidden;
+  flex: 1;
+}
+
+.fold-guide-header {
+  display: grid;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.fold-guide-list {
   list-style: none;
   padding: 0;
   margin: 0;
-  max-height: none;
-  overflow: visible;
+  display: grid;
+  gap: 0.75rem;
+  min-height: 0;
 }
 
-.simulation-fold-guide li {
-  flex: 1 1 calc(50% - 0.25rem);
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.4rem;
-  background: var(--surface-muted);
-  border: 1px solid var(--border-faint);
-  border-radius: var(--radius-button);
-}
-
-.fold-guide-step-header {
-  display: flex;
-  align-items: center;
+.fold-guide-list li {
+  display: grid;
   gap: 0.35rem;
 }
 
+.fold-guide-step-header {
+  display: grid;
+  grid-template-columns: 1.2rem 1fr;
+  gap: 0.5rem;
+  align-items: start;
+}
+
+.fold-guide-text {
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--accent-dark);
+  padding-top: 0.1rem;
+}
+
 .fold-guide-num {
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.2rem;
+  height: 1.2rem;
   border-radius: 50%;
   background: var(--primary-vibrant);
   color: #fff;
@@ -242,29 +198,47 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-}
-
-.fold-guide-text {
-  font-size: 0.68rem;
-  line-height: 1.3;
-  color: var(--accent-dark);
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  margin-top: 0.08rem;
 }
 
 .fold-guide-img {
-  display: none;
+  display: block;
+  width: 100%;
+  max-height: 8rem;
+  object-fit: contain;
+  object-position: center;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-button);
+  background: var(--surface-muted);
+  padding: 0.4rem;
+  image-rendering: crisp-edges;
+  pointer-events: none;
+  margin-top: 0.25rem;
 }
 
-/* Prevent scrollbars in folding guide */
-.simulation-guide-panel .scrollbar-hide {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+.simulation-status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.75rem;
+  padding: 0.28rem 0.65rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-pill);
+  background: var(--surface-bg);
+  color: var(--accent-dark);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  flex-shrink: 0;
 }
-.simulation-guide-panel .scrollbar-hide::-webkit-scrollbar {
-  display: none;
+
+/* 3D canvas elements */
+.zine-3d-canvas,
+.zine-3d-fallback-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .booklet-preview-container {
@@ -564,54 +538,32 @@
   pointer-events: none;
 }
 
+/* Responsive panel styles */
 @media (max-width: 1023px) {
-  .simulation-modal-shell { padding: 0.75rem; gap: 0.75rem; }
-  .simulation-modal-body {
-    grid-template-columns: 1fr;
-    overflow-y: auto;
-    padding-right: 0.1rem;
-  }
-  .simulation-canvas-stage { min-height: 18rem; }
-  .simulation-sidebar { overflow: visible; padding-right: 0; }
+  .fold-viewer-stage { min-height: 14rem; }
+  .fold-viewer-slider-row { grid-template-columns: 1fr; gap: 0.5rem; }
+  .fold-viewer-step-grid { grid-template-columns: 1fr; gap: 0.5rem; }
+  .fold-booklet-preview-container { min-height: 10rem; }
 }
 
 @media (max-width: 767px) {
-  .simulation-modal-shell { padding: 0.5rem; gap: 0.5rem; }
-
-  .simulation-modal-header {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-    padding: 0.85rem;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-panel);
-    background: var(--surface-bg);
-    box-shadow: var(--shadow-md);
+  .fold-viewer-stage { min-height: 12rem; }
+  .fold-viewer-header,
+  .fold-booklet-header,
+  .fold-guide-header {
+    gap: 0.25rem;
   }
-
-  .simulation-modal-summary,
-  .simulation-panel-note,
-  .simulation-helper { font-size: 0.8rem; }
-
-  .simulation-meta-chip,
-  .simulation-status-chip {
-    min-height: 1.6rem;
-    padding: 0.25rem 0.55rem;
-    font-size: 0.6rem;
+  .fold-viewer-kicker,
+  .fold-booklet-kicker,
+  .fold-guide-kicker {
+    font-size: 0.65rem;
   }
-
-  .simulation-canvas-panel,
-  .simulation-panel { padding: 0.85rem; }
-
-  .simulation-panel-top {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 0.5rem;
+  .fold-viewer-title,
+  .fold-booklet-title,
+  .fold-guide-title {
+    font-size: 0.85rem;
   }
-
-  .simulation-slider-row { grid-template-columns: 1fr; gap: 0.5rem; }
-  .simulation-canvas-stage { min-height: 13rem; }
-  .simulation-step-grid { grid-template-columns: 1fr; gap: 0.5rem; }
-
-  .booklet-preview-container { min-height: 10rem; padding: 0.75rem; }
+  .fold-booklet-preview-container { min-height: 9rem; padding: 0.75rem; }
+  .fold-guide-list { gap: 0.5rem; }
+  .fold-guide-img { max-height: 6rem; padding: 0.3rem; }
 }


### PR DESCRIPTION
### Summary
Breaks the single "Preview Fold" modal into three independent, draggable grid panels: a 3D Fold Viewer, a Booklet Preview, and a Fold Guide.

### Problem
The Preview Fold feature was bundled into one modal-style panel containing the 3D simulation, booklet preview, and folding instructions. This made it hard to reposition, resize, or view alongside other panels since everything was locked into a single fixed layout.

### Solution
The original "Preview Fold" panel is now just a trigger card, and the 3D viewer, booklet preview, and fold guide are broken out into their own separate grid-stack panels that can be independently dragged, resized, and toggled visible/hidden.

### Key Changes
- Renamed the original panel to `preview-fold-trigger` (`gs-id`, card id) to act solely as the entry point.
- Added new `fold-viewer` grid-stack panel containing the 3D simulation stage, step controls, and slider, initially hidden via `.hidden` class.
- Added new `fold-booklet` grid-stack panel with the booklet spread preview and prev/next navigation.
- Added new `fold-guide` grid-stack panel with the step-by-step folding instructions list.
- Replaced monolithic `.simulation-modal-*` / `.simulation-canvas-*` / `.simulation-sidebar` CSS classes with panel-scoped classes (`.fold-viewer-*`, `.fold-booklet-*`, `.fold-guide-*`) for headers, stages, controls, and lists.
- Reworked `.fold-guide-list`/`.fold-guide-img`/`.fold-guide-text` styles to support full step images and readable text instead of clamped two-line entries.
- Updated responsive (max-width 1023px / 767px) styles to target the new per-panel classes instead of the old modal layout.


---

<a href="https://builder.io/app/projects/95b351fbb0b940f2a502/iron-dune-fguvyax2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://95b351fbb0b940f2a502-iron-dune-fguvyax2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=95b351fbb0b940f2a502&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 416`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>95b351fbb0b940f2a502</projectId>-->
<!--<branchName>iron-dune-fguvyax2</branchName>-->