### PR TITLE
Punk-ify UI: bolder zine aesthetic and light theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       })();
     </script>
     <style>
-      html, body { background-color: #0d0d0d; }
+      html, body { background-color: #fafafa; }
       html[data-theme="dark"], html[data-theme="dark"] body { background-color: #080808; }
     </style>
 </head>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -225,7 +225,6 @@ input[type="number"].workspace-config-input::-webkit-outer-spin-button {
   overflow: hidden;
   background: var(--surface-muted);
   box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.6);
-  transform: rotate(0.5deg);
 }
 
 .orientation-seg-btn {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -220,11 +220,12 @@ input[type="number"].workspace-config-input::-webkit-outer-spin-button {
 /* Orientation segmented control */
 .orientation-seg {
   display: flex;
-  border: 2px solid var(--primary-vibrant);
-  border-radius: 3px;
+  border: 3px solid #000;
+  border-radius: 2px;
   overflow: hidden;
   background: var(--surface-muted);
-  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.6);
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.6);
+  transform: rotate(0.5deg);
 }
 
 .orientation-seg-btn {
@@ -236,7 +237,7 @@ input[type="number"].workspace-config-input::-webkit-outer-spin-button {
   min-height: 2.25rem;
   padding: 0.3rem 0.4rem;
   font-size: 0.8rem;
-  font-weight: 600;
+  font-weight: 900;
   color: var(--muted-ink);
   background: transparent;
   border: none;
@@ -244,11 +245,12 @@ input[type="number"].workspace-config-input::-webkit-outer-spin-button {
   transition: background 0.15s ease, color 0.15s ease;
   line-height: 1;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
+  font-family: 'Comic Sans MS', 'Courier New', monospace;
 }
 
 .orientation-seg-btn + .orientation-seg-btn {
-  border-left: 2px solid var(--primary-vibrant);
+  border-left: 3px solid #000;
 }
 
 .orientation-seg-btn.active {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -29,10 +29,11 @@ body::-webkit-scrollbar {
   padding: 0 0.875rem;
   height: 2.5rem;
   flex-shrink: 0;
-  background: var(--surface-bg);
-  border-bottom: 2px solid var(--primary-vibrant);
+  background: var(--primary-vibrant);
+  border-bottom: 4px solid #000;
   z-index: 20;
-  box-shadow: 0 3px 0 rgba(0, 0, 0, 0.8);
+  box-shadow: 0 5px 0 rgba(0, 0, 0, 0.8);
+  transform: skewX(-1deg);
 }
 
 .app-brand-mark {
@@ -52,10 +53,12 @@ body::-webkit-scrollbar {
 
 .app-title {
   font-size: 0.88rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
+  font-weight: 900;
+  letter-spacing: 0.05em;
   white-space: nowrap;
-  color: var(--accent-dark);
+  color: #000;
+  font-family: 'Comic Sans MS', 'Courier New', monospace;
+  text-transform: uppercase;
 }
 
 .app-header-actions {
@@ -126,11 +129,12 @@ body::-webkit-scrollbar {
 /* ─── Panel (snap-card) ──────────────────────────────────── */
 .snap-card {
   background: var(--surface-bg);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-panel);
-  box-shadow: var(--shadow-md), 2px 2px 0 rgba(255, 45, 45, 0.3);
+  border: 3px solid #000;
+  border-radius: 2px;
+  box-shadow: var(--shadow-md), 5px 5px 0 rgba(255, 45, 45, 0.6);
   transition: box-shadow 0.15s ease;
   position: relative;
+  transform: rotate(-0.2deg);
 }
 
 .snap-card::before {
@@ -159,8 +163,8 @@ body::-webkit-scrollbar {
   height: 1.875rem;
   cursor: grab;
   user-select: none;
-  background: var(--surface-muted);
-  border-bottom: 2px solid rgba(255, 45, 45, 0.4);
+  background: linear-gradient(135deg, var(--primary-vibrant) 0%, rgba(255, 45, 45, 0.8) 100%);
+  border-bottom: 3px solid #000;
   flex-shrink: 0;
   position: relative;
 }
@@ -179,21 +183,23 @@ body::-webkit-scrollbar {
 
 .snap-card-grip {
   font-size: 13px;
-  color: var(--muted-ink);
-  opacity: 0.45;
+  color: #000;
+  opacity: 0.8;
   flex-shrink: 0;
   transition: opacity 0.15s;
+  font-weight: 900;
 }
 
-.snap-card:hover .snap-card-grip { opacity: 0.75; }
+.snap-card:hover .snap-card-grip { opacity: 1; }
 
 .snap-card-label {
   font-size: 0.62rem;
-  font-weight: 700;
-  letter-spacing: 0.09em;
+  font-weight: 900;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--muted-ink);
+  color: #000;
   white-space: nowrap;
+  font-family: 'Comic Sans MS', 'Courier New', monospace;
 }
 
 /* ─── Panel body ─────────────────────────────────────────── */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -142,8 +142,11 @@ body::-webkit-scrollbar {
   inset: 0;
   border-radius: var(--radius-panel);
   pointer-events: none;
-  opacity: 0.08;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='d'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='2' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23d)' opacity='0.4'/%3E%3C/svg%3E");
+  opacity: 0.12;
+  background-image:
+    url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='d'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='2' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23d)' opacity='0.4'/%3E%3C/svg%3E"),
+    url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke='%23000' stroke-width='0.2' opacity='0.15' fill='none'%3E%3Ccircle cx='25' cy='25' r='1'/%3E%3Ccircle cx='75' cy='25' r='1'/%3E%3Ccircle cx='25' cy='75' r='1'/%3E%3Ccircle cx='75' cy='75' r='1'/%3E%3C/g%3E%3C/svg%3E");
+  background-size: auto, 100px 100px;
 }
 
 /* drag-active state */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -25,14 +25,15 @@ body::-webkit-scrollbar {
 .app-header {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
   padding: 0 0.875rem;
-  height: 2.5rem;
+  height: 3.5rem;
   flex-shrink: 0;
   background: #000;
   border-bottom: 3px solid var(--primary-vibrant);
   z-index: 20;
-  box-shadow: 0 3px 0 rgba(255, 45, 45, 0.8);
+  box-shadow: 0 3px 0 rgba(255, 90, 90, 0.8);
 }
 
 .app-brand-mark {
@@ -41,10 +42,11 @@ body::-webkit-scrollbar {
   justify-content: center;
   flex-shrink: 0;
   background: transparent;
+  margin-right: auto;
 }
 
 .app-brand-mark .logo-image {
-  height: 2rem;
+  height: 2.5rem;
   width: auto;
   object-fit: contain;
   background: transparent;
@@ -64,7 +66,6 @@ body::-webkit-scrollbar {
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  margin-left: auto;
 }
 
 /* ─── GridStack wrapper ──────────────────────────────────── */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -29,11 +29,10 @@ body::-webkit-scrollbar {
   padding: 0 0.875rem;
   height: 2.5rem;
   flex-shrink: 0;
-  background: var(--primary-vibrant);
-  border-bottom: 4px solid #000;
+  background: #000;
+  border-bottom: 3px solid var(--primary-vibrant);
   z-index: 20;
-  box-shadow: 0 5px 0 rgba(0, 0, 0, 0.8);
-  transform: skewX(-1deg);
+  box-shadow: 0 3px 0 rgba(255, 45, 45, 0.8);
 }
 
 .app-brand-mark {
@@ -56,7 +55,7 @@ body::-webkit-scrollbar {
   font-weight: 900;
   letter-spacing: 0.05em;
   white-space: nowrap;
-  color: #000;
+  color: var(--accent-dark);
   font-family: 'Comic Sans MS', 'Courier New', monospace;
   text-transform: uppercase;
 }
@@ -134,7 +133,6 @@ body::-webkit-scrollbar {
   box-shadow: var(--shadow-md), 5px 5px 0 rgba(255, 45, 45, 0.6);
   transition: box-shadow 0.15s ease;
   position: relative;
-  transform: rotate(-0.2deg);
 }
 
 .snap-card::before {

--- a/src/styles/textures.css
+++ b/src/styles/textures.css
@@ -2,19 +2,25 @@
 
 :root {
   /* Heavy xerox/photocopy noise for that scanned-flyer feel */
-  --texture-xerox: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='xrx'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.8' numOctaves='5' seed='2' stitchTiles='stitch'/%3E%3CfeDisplacementMap in='SourceGraphic' scale='0.4'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' fill='%23000000' filter='url(%23xrx)' opacity='0.4'/%3E%3C/svg%3E");
+  --texture-xerox: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='xrx'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='2.2' numOctaves='6' seed='2' stitchTiles='stitch'/%3E%3CfeDisplacementMap in='SourceGraphic' scale='0.8'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' fill='%23000000' filter='url(%23xrx)' opacity='0.6'/%3E%3C/svg%3E");
 
-  /* Film grain with visible specks */
-  --texture-grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0 0.15 0.3 0.45 0.6'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.5'/%3E%3C/svg%3E");
+  /* Film grain with visible specks — more aggressive */
+  --texture-grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='5' stitchTiles='stitch'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0 0.2 0.4 0.6 0.8'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.7'/%3E%3C/svg%3E");
 
   /* Rough scan lines */
   --texture-scanlines: repeating-linear-gradient(
     0deg,
     transparent 0,
-    transparent 2px,
-    rgba(255, 45, 45, 0.03) 2px,
-    rgba(255, 45, 45, 0.03) 4px
+    transparent 1px,
+    rgba(255, 45, 45, 0.08) 1px,
+    rgba(255, 45, 45, 0.08) 3px
   );
+
+  /* Distressed scratch marks */
+  --texture-scratches: url("data:image/svg+xml,%3Csvg viewBox='0 0 600 600' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke='%23000' stroke-width='0.5' opacity='0.25' fill='none'%3E%3Cpath d='M10,50 Q20,45 30,55'/%3E%3Cpath d='M100,20 L95,80'/%3E%3Cpath d='M150,100 Q160,110 145,120'/%3E%3Cpath d='M250,30 L245,90'/%3E%3Cpath d='M300,150 Q310,140 320,160'/%3E%3Cpath d='M400,50 L390,110'/%3E%3Cpath d='M500,200 Q510,195 520,210'/%3E%3Cpath d='M550,80 L540,140'/%3E%3Cpath d='M70,200 Q75,190 85,205'/%3E%3Cpath d='M200,250 L195,310'/%3E%3C/g%3E%3C/svg%3E");
+
+  /* Ink bleed effect */
+  --texture-bleed: url("data:image/svg+xml,%3Csvg viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='bleed'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.4' numOctaves='3' seed='5'/%3E%3CfeDisplacementMap in='SourceGraphic' scale='2' xChannelSelector='R' yChannelSelector='G'/%3E%3C/filter%3E%3Ccircle cx='150' cy='150' r='80' fill='%23ff2d2d' opacity='0.15' filter='url(%23bleed)'/%3E%3C/svg%3E");
 
   --studio-wash: linear-gradient(180deg, var(--bg-warm-highlight) 0%, var(--bg-neutral) 100%);
 }
@@ -39,14 +45,14 @@
   inset: 0;
   pointer-events: none;
   z-index: 0;
-  opacity: 0.45;
+  opacity: 0.6;
   mix-blend-mode: hard-light;
-  background-image: var(--texture-xerox), var(--texture-grain);
-  background-size: 256px 256px, 200px 200px;
+  background-image: var(--texture-xerox), var(--texture-grain), var(--texture-scratches), var(--texture-bleed);
+  background-size: 256px 256px, 200px 200px, 600px 600px, 300px 300px;
 }
 
 [data-theme="dark"] .mobile-zine-app::after {
-  opacity: 0.5;
+  opacity: 0.7;
   mix-blend-mode: overlay;
 }
 

--- a/src/styles/textures.css
+++ b/src/styles/textures.css
@@ -12,15 +12,18 @@
     0deg,
     transparent 0,
     transparent 1px,
-    rgba(255, 45, 45, 0.08) 1px,
-    rgba(255, 45, 45, 0.08) 3px
+    rgba(255, 85, 85, 0.08) 1px,
+    rgba(255, 85, 85, 0.08) 3px
   );
 
   /* Distressed scratch marks */
   --texture-scratches: url("data:image/svg+xml,%3Csvg viewBox='0 0 600 600' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke='%23000' stroke-width='0.5' opacity='0.25' fill='none'%3E%3Cpath d='M10,50 Q20,45 30,55'/%3E%3Cpath d='M100,20 L95,80'/%3E%3Cpath d='M150,100 Q160,110 145,120'/%3E%3Cpath d='M250,30 L245,90'/%3E%3Cpath d='M300,150 Q310,140 320,160'/%3E%3Cpath d='M400,50 L390,110'/%3E%3Cpath d='M500,200 Q510,195 520,210'/%3E%3Cpath d='M550,80 L540,140'/%3E%3Cpath d='M70,200 Q75,190 85,205'/%3E%3Cpath d='M200,250 L195,310'/%3E%3C/g%3E%3C/svg%3E");
 
   /* Ink bleed effect */
-  --texture-bleed: url("data:image/svg+xml,%3Csvg viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='bleed'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.4' numOctaves='3' seed='5'/%3E%3CfeDisplacementMap in='SourceGraphic' scale='2' xChannelSelector='R' yChannelSelector='G'/%3E%3C/filter%3E%3Ccircle cx='150' cy='150' r='80' fill='%23ff2d2d' opacity='0.15' filter='url(%23bleed)'/%3E%3C/svg%3E");
+  --texture-bleed: url("data:image/svg+xml,%3Csvg viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='bleed'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.4' numOctaves='3' seed='5'/%3E%3CfeDisplacementMap in='SourceGraphic' scale='2' xChannelSelector='R' yChannelSelector='G'/%3E%3C/filter%3E%3Ccircle cx='150' cy='150' r='80' fill='%23ff5555' opacity='0.15' filter='url(%23bleed)'/%3E%3C/svg%3E");
+
+  /* Paper texture - crosshatch weave */
+  --texture-paper: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke='%23000' stroke-width='0.3' opacity='0.08'%3E%3Cline x1='0' y1='0' x2='200' y2='200'/%3E%3Cline x1='0' y1='20' x2='200' y2='220'/%3E%3Cline x1='0' y1='40' x2='200' y2='240'/%3E%3Cline x1='0' y1='60' x2='200' y2='260'/%3E%3Cline x1='200' y1='0' x2='0' y2='200'/%3E%3Cline x1='180' y1='0' x2='0' y2='180'/%3E%3Cline x1='160' y1='0' x2='0' y2='160'/%3E%3C/g%3E%3C/svg%3E");
 
   --studio-wash: linear-gradient(180deg, var(--bg-warm-highlight) 0%, var(--bg-neutral) 100%);
 }
@@ -47,13 +50,18 @@
   z-index: 0;
   opacity: 0.6;
   mix-blend-mode: hard-light;
-  background-image: var(--texture-xerox), var(--texture-grain), var(--texture-scratches), var(--texture-bleed);
-  background-size: 256px 256px, 200px 200px, 600px 600px, 300px 300px;
+  background-image: var(--texture-xerox), var(--texture-grain), var(--texture-scratches), var(--texture-bleed), var(--texture-paper);
+  background-size: 256px 256px, 200px 200px, 600px 600px, 300px 300px, 200px 200px;
 }
 
 [data-theme="dark"] .mobile-zine-app::after {
   opacity: 0.7;
   mix-blend-mode: overlay;
+}
+
+[data-theme="light"] .mobile-zine-app::after {
+  opacity: 0.4;
+  mix-blend-mode: multiply;
 }
 
 .app-shell {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,41 +1,41 @@
 @import "tailwindcss";
 
 :root {
-  /* Punk zine palette: black, off-white, bold red */
-  --bg-warm-highlight: #0f0f0f;
-  --bg-warm-shadow: #000000;
-  --bg-neutral: #0d0d0d;
+  /* Light/Day theme: punk zine on white paper */
+  --bg-warm-highlight: #f5f5f5;
+  --bg-warm-shadow: #ffffff;
+  --bg-neutral: #fafafa;
 
-  --surface-bg: #1a1a1a;
-  --surface-strong: #242424;
-  --surface-muted: #141414;
-  --glass-bg-alt: rgba(26, 26, 26, 0.95);
+  --surface-bg: #ffffff;
+  --surface-strong: #f0f0f0;
+  --surface-muted: #f8f8f8;
+  --glass-bg-alt: rgba(255, 255, 255, 0.95);
 
   --surface-paper-stack:
     var(--texture-xerox, none),
-    linear-gradient(165deg, rgba(32, 32, 32, 0.99) 0%, rgba(20, 20, 20, 0.99) 100%);
+    linear-gradient(165deg, rgba(255, 255, 255, 0.99) 0%, rgba(245, 245, 245, 0.99) 100%);
 
-  --accent-dark: #e8e8e8;
-  --accent-ink-soft: #b0b0b0;
+  --accent-dark: #1a1a1a;
+  --accent-ink-soft: #4a4a4a;
   --primary-vibrant: #ff5555;
   --primary-deep: #dd3333;
-  --primary-glow: rgba(255, 85, 85, 0.2);
-  --border-color: rgba(255, 255, 255, 0.15);
-  --border-faint: rgba(255, 255, 255, 0.08);
-  --muted-ink: #909090;
-  --paper-bg: #1f1f1f;
+  --primary-glow: rgba(255, 85, 85, 0.15);
+  --border-color: rgba(0, 0, 0, 0.12);
+  --border-faint: rgba(0, 0, 0, 0.06);
+  --muted-ink: #707070;
+  --paper-bg: #fefefe;
 
-  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.8), 0 4px 12px rgba(0, 0, 0, 0.6);
-  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.85), 0 2px 6px rgba(0, 0, 0, 0.7);
-  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.9), 0 4px 12px rgba(0, 0, 0, 0.8);
-  --shadow-paper: 0 1px 0 rgba(255, 255, 255, 0.05) inset, 0 16px 48px rgba(0, 0, 0, 0.9);
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.08), 0 4px 12px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.1), 0 2px 6px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.12), 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-paper: 0 1px 0 rgba(0, 0, 0, 0.05) inset, 0 16px 48px rgba(0, 0, 0, 0.08);
   --surface-shadow-strong: var(--shadow-paper);
 
   --radius-panel: 0.5rem;
   --radius-button: 0.375rem;
   --radius-pill: 999px;
-  --border-bold: 2px solid rgba(255, 45, 45, 0.6);
-  --border-thin: 1px solid rgba(255, 255, 255, 0.12);
+  --border-bold: 2px solid rgba(255, 85, 85, 0.7);
+  --border-thin: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 /* ── Dark mode: ink-on-black punk zine ─────────────────────────────── */
@@ -69,7 +69,7 @@
   --shadow-paper: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 16px 48px rgba(0, 0, 0, 0.95);
   --surface-shadow-strong: var(--shadow-paper);
 
-  --border-bold: 2px solid rgba(255, 45, 45, 0.7);
+  --border-bold: 2px solid rgba(255, 85, 85, 0.7);
   --border-thin: 1px solid rgba(255, 255, 255, 0.12);
 }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -17,9 +17,9 @@
 
   --accent-dark: #e8e8e8;
   --accent-ink-soft: #b0b0b0;
-  --primary-vibrant: #ff2d2d;
-  --primary-deep: #cc0000;
-  --primary-glow: rgba(255, 45, 45, 0.2);
+  --primary-vibrant: #ff5555;
+  --primary-deep: #dd3333;
+  --primary-glow: rgba(255, 85, 85, 0.2);
   --border-color: rgba(255, 255, 255, 0.15);
   --border-faint: rgba(255, 255, 255, 0.08);
   --muted-ink: #909090;
@@ -55,9 +55,9 @@
 
   --accent-dark: #e0e0e0;
   --accent-ink-soft: #a8a8a8;
-  --primary-vibrant: #ff3333;
-  --primary-deep: #dd0000;
-  --primary-glow: rgba(255, 51, 51, 0.22);
+  --primary-vibrant: #ff5555;
+  --primary-deep: #dd3333;
+  --primary-glow: rgba(255, 85, 85, 0.22);
   --border-color: rgba(255, 255, 255, 0.16);
   --border-faint: rgba(255, 255, 255, 0.08);
   --muted-ink: #888888;

--- a/src/styles/zine-editor.css
+++ b/src/styles/zine-editor.css
@@ -349,8 +349,9 @@
   letter-spacing: 0.08em;
   padding: 2px 5px;
   z-index: 20;
-  top: 0.3rem;
-  left: 0.3rem;
+  bottom: 0.3rem;
+  left: 50%;
+  transform: translateX(-50%);
   border: 2px solid #000;
   border-radius: 2px;
   pointer-events: none;

--- a/src/styles/zine-editor.css
+++ b/src/styles/zine-editor.css
@@ -4,8 +4,8 @@
   --sheet-scale: 1;
   background: white;
   box-shadow: var(--shadow-sm);
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  border-radius: 0.75rem;
+  border: 3px solid #000;
+  border-radius: 1px;
   position: relative;
   flex-shrink: 0;
   transition: all 0.2s ease;
@@ -14,6 +14,7 @@
   overflow: hidden;
   width: min(100%, calc(var(--sheet-width, 210mm) * var(--sheet-scale, 1)));
   aspect-ratio: var(--sheet-width, 210) / var(--sheet-height, 297);
+  transform: rotate(-0.3deg);
 }
 
 [data-theme="dark"] .print-sheet {
@@ -53,7 +54,7 @@
 }
 
 .page-cell {
-  border: 1px dashed rgba(0,0,0,0.12);
+  border: 2px dashed var(--primary-vibrant);
   position: relative;
   display: flex;
   align-items: center;
@@ -62,7 +63,8 @@
   cursor: pointer;
   min-height: 7rem;
   transition: border-color 0.15s ease, background-color 0.15s ease;
-  border-radius: 0;
+  border-radius: 1px;
+  background: linear-gradient(135deg, rgba(255, 45, 45, 0.03) 0%, transparent 100%);
 }
 
 [data-theme="dark"] .page-cell {
@@ -133,16 +135,19 @@
   flex-direction: column;
   align-items: center;
   gap: 0.3rem;
-  background: rgba(239, 68, 68, 0.88);
-  color: white;
-  border-radius: 0.5rem;
+  background: var(--primary-vibrant);
+  color: #000;
+  border-radius: 2px;
+  border: 2px solid #000;
   padding: 0.4rem 0.75rem;
   font-size: 0.65rem;
-  font-weight: 700;
+  font-weight: 900;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   backdrop-filter: blur(2px);
-  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.4);
+  transform: rotate(1deg);
+  font-family: 'Comic Sans MS', 'Courier New', monospace;
 }
 
 .page-cell-remove-hint-inner .material-symbols-outlined {
@@ -217,22 +222,26 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.2rem 0.45rem 0.2rem 0.32rem;
-  border-radius: 999px;
-  border: 1px solid rgba(0,0,0,0.12);
-  background: rgba(255,255,255,0.96);
-  color: #374151;
+  border-radius: 1px;
+  border: 2px solid #000;
+  background: var(--primary-vibrant);
+  color: #000;
   font-size: 0;
   line-height: 1;
   cursor: pointer;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.06);
-  transition: background 0.1s ease, border-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease;
+  box-shadow: 2px 2px 0 rgba(0,0,0,0.3);
+  transition: background 0.1s ease, border-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease, transform 0.1s ease;
   white-space: nowrap;
+  font-weight: 700;
+  text-transform: uppercase;
+  transform: rotate(-0.5deg);
 }
 
 .page-tool-btn:hover {
-  background: #fff;
-  border-color: rgba(0,0,0,0.22);
-  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  background: #ff5555;
+  border-color: #000;
+  box-shadow: 3px 3px 0 rgba(0,0,0,0.4);
+  transform: rotate(0.5deg) scale(1.05);
 }
 
 .page-tool-btn:focus-visible {
@@ -249,36 +258,40 @@
 
 .page-tool-btn .page-tool-label {
   font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: #374151;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  color: #000;
   line-height: 1;
+  font-family: 'Comic Sans MS', 'Courier New', monospace;
 }
 
 [data-theme="dark"] .page-tool-btn {
-  background: rgba(30,40,64,0.95);
-  border-color: rgba(255,255,255,0.14);
-  color: #d1d5db;
+  background: var(--primary-vibrant);
+  border-color: #000;
+  color: #000;
+  box-shadow: 2px 2px 0 rgba(0,0,0,0.5);
 }
 
 [data-theme="dark"] .page-tool-btn:hover {
-  background: rgba(40,52,80,1);
-  border-color: rgba(255,255,255,0.25);
+  background: #ff5555;
+  border-color: #000;
+  box-shadow: 3px 3px 0 rgba(0,0,0,0.6);
 }
 
 [data-theme="dark"] .page-tool-btn .page-tool-icon,
 [data-theme="dark"] .page-tool-btn .page-tool-label {
-  color: #d1d5db;
+  color: #000;
 }
 
 [data-theme="dark"] .page-tool-btn--danger:hover {
-  background: rgba(60,20,20,0.95);
-  border-color: #f87171;
+  background: #ff4444;
+  border-color: #000;
+  box-shadow: 3px 3px 0 rgba(0,0,0,0.6);
 }
 
 [data-theme="dark"] .page-tool-btn--danger:hover .page-tool-icon,
 [data-theme="dark"] .page-tool-btn--danger:hover .page-tool-label {
-  color: #f87171;
+  color: #000;
 }
 
 .page-content-img {
@@ -331,22 +344,25 @@
 
 .page-label {
   position: absolute;
-  background: var(--surface-bg);
-  color: var(--muted-ink);
-  font-family: 'Inter', monospace;
-  font-weight: 600;
+  background: var(--primary-vibrant);
+  color: #000;
+  font-family: 'Comic Sans MS', 'Courier New', monospace;
+  font-weight: 900;
   font-size: 7px;
   line-height: 1;
-  letter-spacing: 0.04em;
-  padding: 2px 4px;
+  letter-spacing: 0.08em;
+  padding: 2px 5px;
   z-index: 20;
   top: 0.3rem;
   left: 0.3rem;
-  border: 1px solid var(--border-faint);
-  border-radius: 999px;
+  border: 2px solid #000;
+  border-radius: 2px;
   pointer-events: none;
-  opacity: 0.75;
+  opacity: 0.95;
   transition: opacity 0.15s ease;
+  transform: rotate(-1.5deg);
+  box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.5);
+  text-transform: uppercase;
 }
 
 .page-cell:hover .page-label,
@@ -366,8 +382,9 @@
 
 .sheet-cut-line-h {
   height: 0;
-  border-top: 2px dashed #ef4444;
+  border-top: 3px dashed var(--primary-vibrant);
   transform: translateY(-50%);
+  opacity: 0.9;
 }
 
 .sheet-cut-line::before,
@@ -376,10 +393,11 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 50%;
-  background: #ef4444;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 1px;
+  background: var(--primary-vibrant);
+  border: 1px solid #000;
 }
 
 .sheet-cut-line::before { left: 0; }
@@ -389,16 +407,19 @@
   position: absolute;
   left: 50%;
   top: 50%;
-  transform: translate(-50%, -50%);
-  background: #ef4444;
-  color: white;
+  transform: translate(-50%, -50%) rotate(-1deg);
+  background: var(--primary-vibrant);
+  color: #000;
   font-size: 0.55rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
+  font-weight: 900;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  padding: 0.15rem 0.4rem;
-  border-radius: 999px;
+  padding: 0.15rem 0.5rem;
+  border-radius: 2px;
+  border: 1px solid #000;
   white-space: nowrap;
+  font-family: 'Comic Sans MS', 'Courier New', monospace;
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.3);
 }
 
 /* ── Drag-to-reorder live preview ─────────────────── */

--- a/src/styles/zine-editor.css
+++ b/src/styles/zine-editor.css
@@ -21,6 +21,24 @@
   border-color: rgba(255, 255, 255, 0.08);
 }
 
+.print-sheet::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      transparent 0,
+      transparent 2px,
+      rgba(0, 0, 0, 0.03) 2px,
+      rgba(0, 0, 0, 0.03) 4px
+    ),
+    url("data:image/svg+xml,%3Csvg viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='grain'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' seed='1'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23grain)' opacity='0.15'/%3E%3C/svg%3E");
+  opacity: 0.4;
+  z-index: 1;
+}
+
 @media print {
   .print-sheet {
     border: none;
@@ -403,7 +421,7 @@
   position: absolute;
   left: 50%;
   top: 50%;
-  transform: translate(-50%, -50%) rotate(-1deg);
+  transform: translate(-50%, -50%);
   background: var(--primary-vibrant);
   color: #000;
   font-size: 0.55rem;
@@ -416,6 +434,7 @@
   white-space: nowrap;
   font-family: 'Comic Sans MS', 'Courier New', monospace;
   box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.3);
+  z-index: 15;
 }
 
 /* ── Drag-to-reorder live preview ─────────────────── */

--- a/src/styles/zine-editor.css
+++ b/src/styles/zine-editor.css
@@ -14,7 +14,6 @@
   overflow: hidden;
   width: min(100%, calc(var(--sheet-width, 210mm) * var(--sheet-scale, 1)));
   aspect-ratio: var(--sheet-width, 210) / var(--sheet-height, 297);
-  transform: rotate(-0.3deg);
 }
 
 [data-theme="dark"] .print-sheet {
@@ -146,7 +145,6 @@
   letter-spacing: 0.08em;
   backdrop-filter: blur(2px);
   box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.4);
-  transform: rotate(1deg);
   font-family: 'Comic Sans MS', 'Courier New', monospace;
 }
 
@@ -230,18 +228,16 @@
   line-height: 1;
   cursor: pointer;
   box-shadow: 2px 2px 0 rgba(0,0,0,0.3);
-  transition: background 0.1s ease, border-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease, transform 0.1s ease;
+  transition: background 0.1s ease, border-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease;
   white-space: nowrap;
   font-weight: 700;
   text-transform: uppercase;
-  transform: rotate(-0.5deg);
 }
 
 .page-tool-btn:hover {
   background: #ff5555;
   border-color: #000;
   box-shadow: 3px 3px 0 rgba(0,0,0,0.4);
-  transform: rotate(0.5deg) scale(1.05);
 }
 
 .page-tool-btn:focus-visible {
@@ -360,7 +356,6 @@
   pointer-events: none;
   opacity: 0.95;
   transition: opacity 0.15s ease;
-  transform: rotate(-1.5deg);
   box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.5);
   text-transform: uppercase;
 }


### PR DESCRIPTION
### Summary
Reworks the app's visual style to lean into a bolder, more "punk rock" zine aesthetic instead of the previous clean look, and switches the default theme to a light/day palette.

### Problem
The UI felt too clean and polished, lacking the raw, DIY zine energy the app is meant to evoke. The top toolbar, panels, and print sheet editor all needed a rougher, more textured, high-contrast treatment, and the logo needed a background that made it stand out.

### Solution
Introduced heavier borders, offset drop shadows, uppercase Comic Sans/Courier styling, and layered SVG noise/texture backgrounds across headers, panels, and the print sheet. Changed the base color scheme from dark to a light paper background while keeping a black top toolbar for logo contrast, and refreshed the accent red to a slightly softer shade.

### Key Changes
- **`index.html`**: Changed base body background from dark (`#0d0d0d`) to light (`#fafafa`).
- **`theme.css`**: Flipped the light theme variables to a white/paper-based palette (backgrounds, surfaces, borders, shadows) and softened the primary red accent (`#ff2d2d` → `#ff5555`) across both light and dark themes.
- **`layout.css`**: 
  - Made `.app-header` black, taller (2.5rem → 3.5rem), and centered its content with the logo pushed via `margin-right: auto`.
  - Bolder `.app-title` styling (heavier weight, uppercase, monospace/Comic Sans font).
  - Thicker black borders and larger offset shadows on `.snap-card` panels.
  - Added a second layered SVG texture (dotted pattern) to `.snap-card::before`.
  - Restyled `.snap-card-header` with a red gradient, black border, and bolder grip/label text.
- **`components.css`**: Heavier black borders, bigger box-shadow offset, and Comic Sans/monospace uppercase styling for the orientation segmented control.
- **`textures.css`**: Intensified existing xerox/grain/scanline textures and added new `--texture-scratches`, `--texture-bleed`, and `--texture-paper` SVG texture variables for more distressed texture options.
- **`zine-editor.css`**:
  - Added a grain/scanline overlay (`::before`) to `.print-sheet` with thicker black border.
  - Restyled `.page-cell` borders to dashed red with a subtle gradient background.
  - Reworked page tool buttons, remove-hint badge, and page label with bold black borders, offset shadows, uppercase Comic Sans text, and red accent backgrounds.
  - Moved `.page-label` to bottom-center of the page cell and gave it a bold pill/box styling.
  - Restyled the "cut here" line and label (`.sheet-cut-line*`) with thicker dashed red lines, square-ish red circles/labels, black borders, and offset shadows.


---

<a href="https://builder.io/app/projects/b1d0d280a3284a65a938/shimmer-shuttle-bi9fwbuf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://b1d0d280a3284a65a938-shimmer-shuttle-bi9fwbuf.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=b1d0d280a3284a65a938&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 420`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b1d0d280a3284a65a938</projectId>-->
<!--<branchName>shimmer-shuttle-bi9fwbuf</branchName>-->