### PR TITLE
🧹 Remove unused cn utility function and dependencies

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -8,7 +8,7 @@ function initThemeToggle() {
   const themeToggle = document.getElementById('theme-toggle');
   const themeIcon = document.getElementById('theme-icon');
 
-  if (!themeToggle || !themeIcon) return;
+  if (!themeToggle || !themeIcon) { return; }
 
   themeToggle.addEventListener('click', () => {
     const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,16 +1,5 @@
 import DOMPurify from 'dompurify';
 // Utility functions for the PDF Zine Maker
-import { clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-/**
- * Utility for merging Tailwind classes with clsx
- * @param {...any} inputs - Class values to merge
- * @returns {string} Merged class string
- */
-export function cn(...inputs) {
-  return twMerge(clsx(inputs));
-}
 
 /**
  * Debounce function to limit how often a function can be called


### PR DESCRIPTION
🎯 **What:** Removed the unused `cn` function and its related dependencies (`clsx`, `tailwind-merge`) from `src/utils/helpers.js`.

💡 **Why:** The `cn` utility function was defined but never used anywhere in the project. Removing it (along with its specific imports) eliminates dead code, improving codebase cleanliness and maintainability.

✅ **Verification:** Ran `grep` to confirm `cn`, `clsx`, and `twMerge` were only used in this definition in `src/utils/helpers.js`. Ran `npx eslint src/utils/helpers.js` with no lint errors, and ran the unit test suite which all passed successfully.

✨ **Result:** A cleaner `helpers.js` file without unused utility functions and third-party import overhead.

---
*PR created automatically by Jules for task [17980162956720486824](https://jules.google.com/task/17980162956720486824) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Clean up helpers utilities by removing the unused cn function and its clsx and tailwind-merge dependencies.