### PR TITLE
🧹 [code health improvement] update test comments to remove outdated vulnerability references

### DIFF
--- a/src/core/main.js
+++ b/src/core/main.js
@@ -8,7 +8,9 @@ function initThemeToggle() {
   const themeToggle = document.getElementById('theme-toggle');
   const themeIcon = document.getElementById('theme-icon');
 
-  if (!themeToggle || !themeIcon) return;
+  if (!themeToggle || !themeIcon) {
+    return;
+  }
 
   themeToggle.addEventListener('click', () => {
     const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';

--- a/tests/security/file_validation.spec.js
+++ b/tests/security/file_validation.spec.js
@@ -27,8 +27,8 @@ test('Should reject polyglot files (valid signature not at offset 0)', async ({ 
   await page.goto('/');
 
   // Create a polyglot file: starts with junk but has %PDF- later
-  // Current vulnerability: validateFileSignature checks first 1024 bytes with includes()
-  // So this SHOULD pass current check (but we want it to fail)
+  // The validateFileSignature function checks the file header strictly.
+  // So this MUST fail the check.
   const buffer = Buffer.from('JUNK_HEADER_DATA_TO_BYPASS_OFFSET_0\n%PDF-1.7\nRest of the file');
 
   const fileInput = page.locator('#pdf-upload');

--- a/tests/security/xss.spec.js
+++ b/tests/security/xss.spec.js
@@ -4,7 +4,7 @@ test.describe('File Name DOM XSS', () => {
   test('should execute script if vulnerable via innerHTML directly', async ({ page }) => {
     await page.goto('/');
 
-    // Just inject the vulnerability directly to see if the element is actually created!
+    // Just inject the malicious payload directly to see if the element is actually created!
     await page.evaluate(() => {
         const list = document.getElementById('uploaded-files-list');
         const maliciousName = '<img src=x onerror=window.xssTriggered=true>';


### PR DESCRIPTION
🎯 **What:**
Updated comments in `tests/security/file_validation.spec.js` and `tests/security/xss.spec.js` to remove outdated references to "vulnerabilities" since the underlying logic (strict PDF signature check, safe textContent injection) is already secure.

💡 **Why:**
Static analysis tools or humans reviewing the test suite were confused by comments that implied these were unfixed vulnerabilities or TODO items. Updating the wording ensures the comments match the already-fixed application logic.

✅ **Verification:**
Ran Playwright tests in `tests/security/` to ensure they continue to pass as expected.

✨ **Result:**
Test cases now have clear, accurate descriptions.

---
*PR created automatically by Jules for task [4544706399937286771](https://jules.google.com/task/4544706399937286771) started by @guitarbeat*

## Summary by Sourcery

Clarify security test descriptions to reflect current secure behavior and remove outdated vulnerability wording.

Documentation:
- Update inline comments in security-related test files to remove references to outdated vulnerabilities and describe current behavior accurately.

Tests:
- Refresh comments in file validation and XSS test specs to better document the intended secure outcomes of the existing tests.