### PR TITLE
⚙️ Improve GitHub Actions: harden permissions, add concurrency, freeze lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -25,7 +32,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Run lint
         run: pnpm lint

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,13 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday at midnight
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This PR applies standard CI hardening improvements to the GitHub Actions workflows.

### Changes
- [x] Add `permissions: contents: read` to `ci.yml` and `security.yml` (least-privilege token)
- [x] Add concurrency groups to both workflows to cancel superseded runs
- [x] Change `pnpm install --no-frozen-lockfile` to `--frozen-lockfile` in `ci.yml` for reproducible CI installs

---
*Automated PR created via GitHub API.*

## Summary by Sourcery

Harden GitHub Actions CI and security workflows by restricting token permissions, adding concurrency controls, and enforcing reproducible dependency installs.

CI:
- Limit GitHub Actions workflow permissions to read-only repository contents for CI and security workflows.
- Add concurrency groups to CI and security workflows to cancel superseded runs and avoid overlapping executions.
- Enforce frozen pnpm lockfile usage in the CI workflow to ensure reproducible dependency installation.