### PR TITLE
🧪 Add tests for cn utility function

### DIFF
--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { clampNumber, formatFileSize, isNumber, debounce, parseBoundedInteger, resizeAndFillArray } from '../../src/utils/helpers.js';
+import { cn, clampNumber, formatFileSize, isNumber, debounce, parseBoundedInteger, resizeAndFillArray } from '../../src/utils/helpers.js';
 import {
   classifyFileKind,
   getFileTypeLabel,
@@ -8,6 +8,27 @@ import {
 } from '../../src/utils/fileValidation.js';
 
 test.describe('Utils', () => {
+  test('cn', () => {
+    // Standard string merging
+    expect(cn('class1', 'class2')).toBe('class1 class2');
+
+    // Conditional classes
+    expect(cn('class1', { class2: true, class3: false })).toBe('class1 class2');
+    expect(cn({ class1: true }, { class2: true })).toBe('class1 class2');
+
+    // Arrays
+    expect(cn(['class1', 'class2'])).toBe('class1 class2');
+    expect(cn(['class1', { class2: true }])).toBe('class1 class2');
+
+    // Handling undefined/null values
+    expect(cn('class1', undefined, null, false, 'class2')).toBe('class1 class2');
+
+    // Tailwind conflict resolution
+    expect(cn('px-2 py-1', 'px-4')).toBe('py-1 px-4');
+    expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500');
+    expect(cn('bg-red-500 p-4', 'bg-blue-500')).toBe('p-4 bg-blue-500');
+  });
+
   test('formatFileSize', () => {
     expect(formatFileSize(0)).toBe('0 B');
     expect(formatFileSize(1024)).toBe('1.0 KB');


### PR DESCRIPTION
🎯 **What:** The testing gap for the `cn` utility function in `src/utils/helpers.js` has been addressed. The `cn` function is a crucial wrapper around `clsx` and `twMerge` but previously lacked dedicated tests.

📊 **Coverage:** The new tests cover:
- Standard string merging
- Conditional classes using object syntax (`{ class: condition }`)
- Array syntax combining strings and objects
- Handling of undefined, null, and false values
- Proper Tailwind CSS conflict resolution (e.g. `px-2 py-1` vs `px-4`)

✨ **Result:** Test coverage for the utility functions has improved, ensuring any future updates to underlying libraries (`clsx`, `tailwind-merge`) or the `cn` implementation itself can be confidently verified without risk of breaking class resolution.

---
*PR created automatically by Jules for task [18352275081060856130](https://jules.google.com/task/18352275081060856130) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add tests for the cn helper covering string merging, conditional classes, array inputs, falsy values, and Tailwind class conflict resolution.