### PR TITLE
🧹 [Code Health] Remove unused cn utility function

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,17 +1,5 @@
 import DOMPurify from 'dompurify';
 // Utility functions for the PDF Zine Maker
-import { clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-/**
- * Utility for merging Tailwind classes with clsx
- * @param {...any} inputs - Class values to merge
- * @returns {string} Merged class string
- */
-export function cn(...inputs) {
-  return twMerge(clsx(inputs));
-}
-
 /**
  * Debounce function to limit how often a function can be called
  * @param {Function} func - Function to debounce


### PR DESCRIPTION
🎯 **What:** Removed the unused `cn` utility function and its associated imports (`clsx` and `twMerge`) from `src/utils/helpers.js`.
💡 **Why:** The `cn` function is not referenced anywhere in the project. Removing it safely eliminates dead code, improving the maintainability and readability of the codebase without affecting functionality.
✅ **Verification:**
- Verified no remaining uses of `cn` exist using `grep` search.
- Verified no remaining uses of `clsx` and `twMerge` exist using `grep` search.
- Ran tests (`pnpm test` and `pnpm test tests/unit/utils.spec.js`) to ensure no functionality is broken.
- Ran lint checks (`npx eslint src/utils/helpers.js`) to ensure no linting errors.
✨ **Result:** A cleaner `src/utils/helpers.js` file with dead code eliminated.

---
*PR created automatically by Jules for task [14952155699726985339](https://jules.google.com/task/14952155699726985339) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Remove the unused cn helper and its clsx and twMerge imports from src/utils/helpers.js to simplify the utilities file.