### PR TITLE
🧹 [Refactor Zine3DViewer loadPages to reduce complexity]

### DIFF
--- a/src/components/Zine3DViewer.js
+++ b/src/components/Zine3DViewer.js
@@ -359,8 +359,7 @@ export class Zine3DViewer {
    */
   loadPages(imageUrls) {
     if (this.isFallbackMode) {
-      this.fallbackPages = (imageUrls || []).map((page) => normalizePreviewPage(page));
-      this.renderFallback();
+      this.loadFallbackPages(imageUrls);
       return;
     }
 
@@ -374,6 +373,15 @@ export class Zine3DViewer {
     this.createSeams();
     this.createGuides();
 
+    this.setupInitialCameraView();
+  }
+
+  loadFallbackPages(imageUrls) {
+    this.fallbackPages = (imageUrls || []).map((page) => normalizePreviewPage(page));
+    this.renderFallback();
+  }
+
+  setupInitialCameraView() {
     // Initialize layout flat
     this.setFoldProgress(0);
     


### PR DESCRIPTION
🎯 **What:**
Extracted logic out of the bloated `loadPages` method in `src/components/Zine3DViewer.js` into two new focused helper methods: `loadFallbackPages(imageUrls)` and `setupInitialCameraView()`.

💡 **Why:**
This improves the maintainability and readability of `Zine3DViewer.js`. By encapsulating the fallback loading logic and the initial layout/camera positioning logic into their own dedicated methods, the main `loadPages` function now clearly reads as an orchestrated sequence of steps without exposing its granular implementation details.

✅ **Verification:**
1. Confirmed extractions matched the original logic line-for-line.
2. Verified the file against linting rules using `npx eslint src/components/Zine3DViewer.js`.
3. Executed the full test suite via `pnpm test` and ensured that all isolated unit tests (like `mini_zine_fold` and `mini_zine_layout`) passed successfully without `ReferenceError`s.

✨ **Result:**
The `loadPages` function is now significantly shorter, adhering to cleaner separation of concerns, while all 3D mesh creation, layout setup, and fallback rendering behavior remains intact.

---
*PR created automatically by Jules for task [9574432781700245508](https://jules.google.com/task/9574432781700245508) started by @guitarbeat*

## Summary by Sourcery

Refactor Zine3DViewer page loading to delegate fallback handling and initial camera setup to dedicated helper methods.

Enhancements:
- Extract fallback page handling into a dedicated loadFallbackPages helper in Zine3DViewer.
- Extract initial layout and camera setup into a dedicated setupInitialCameraView helper in Zine3DViewer.