### PR TITLE
🧪 [testing improvement] Add unit tests for cn utility function

### DIFF
--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { clampNumber, formatFileSize, isNumber, debounce, parseBoundedInteger, resizeAndFillArray } from '../../src/utils/helpers.js';
+import { clampNumber, formatFileSize, isNumber, debounce, parseBoundedInteger, resizeAndFillArray, cn } from '../../src/utils/helpers.js';
 import {
   classifyFileKind,
   getFileTypeLabel,
@@ -8,6 +8,28 @@ import {
 } from '../../src/utils/fileValidation.js';
 
 test.describe('Utils', () => {
+
+  test('cn', () => {
+    // Basic class merging
+    expect(cn('class1', 'class2')).toBe('class1 class2');
+
+    // clsx behavior: objects
+    expect(cn({ class1: true, class2: false, class3: true })).toBe('class1 class3');
+
+    // clsx behavior: arrays
+    expect(cn(['class1', 'class2'])).toBe('class1 class2');
+
+    // twMerge behavior: Tailwind class conflict resolution
+    expect(cn('p-4', 'p-8')).toBe('p-8');
+    expect(cn('bg-red-500', 'bg-blue-500')).toBe('bg-blue-500');
+
+    // Complex composition
+    expect(cn('text-sm', { 'text-lg': true, 'font-bold': false }, ['flex', 'items-center'], 'text-xl')).toBe('flex items-center text-xl');
+
+    // Edge cases: falsy values
+    expect(cn(null, undefined, false, 0, '', 'class1')).toBe('class1');
+  });
+
   test('formatFileSize', () => {
     expect(formatFileSize(0)).toBe('0 B');
     expect(formatFileSize(1024)).toBe('1.0 KB');


### PR DESCRIPTION
🎯 **What:** 
The `cn` utility function in `src/utils/helpers.js` was previously untested. This function merges Tailwind classes utilizing `clsx` and `twMerge`.

📊 **Coverage:** 
Unit tests were added to `tests/unit/utils.spec.js` covering:
*   Basic string merging behavior.
*   `clsx` behaviors for objects and arrays.
*   `twMerge` behaviors for Tailwind class conflict resolution.
*   Complex composition (combining strings, arrays, and objects).
*   Edge cases and handling of falsy values.

✨ **Result:** 
The `cn` utility function is now fully covered by unit tests, increasing the test coverage and ensuring that future updates to `tailwind-merge` or `clsx` won't break the CSS class composition logic silently.

---
*PR created automatically by Jules for task [11827652078002932355](https://jules.google.com/task/11827652078002932355) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add comprehensive unit tests for the cn helper covering basic merging, clsx object/array handling, Tailwind conflict resolution, complex compositions, and falsy-value edge cases.