### PR TITLE
🧹 Fix unused catch block error variable in PDFProcessor

### DIFF
--- a/src/services/PDFProcessor.js
+++ b/src/services/PDFProcessor.js
@@ -305,8 +305,8 @@ export class PDFProcessor extends MediaProcessor {
   async cleanupFailedLoad() {
     try {
       await this.loadingTask?.destroy();
-    } catch (destroyError) {
-      void destroyError;
+    } catch (_destroyError) {
+      void _destroyError;
     }
     this.loadingTask = null;
 


### PR DESCRIPTION
🎯 **What:** Renamed the unused catch block variable `destroyError` to `_destroyError` in `src/services/PDFProcessor.js`.

💡 **Why:** This improves maintainability by resolving the unused catch block error variable according to standard conventions, telling linters to explicitly ignore it, and following repository standards for unused variables.

✅ **Verification:** Verified that `npx eslint src/services/PDFProcessor.js` passes with no errors. The existing test suite was also run to ensure no regressions were introduced. Note: Left `void _destroyError;` in place inside the catch block as removing it would trigger a `no-empty` block rule from ESLint based on strict repository configuration.

✨ **Result:** Cleaned up linting/unused variable concerns in `PDFProcessor.js` cleanupFailedLoad without altering program logic.

---
*PR created automatically by Jules for task [18221129082439197928](https://jules.google.com/task/18221129082439197928) started by @guitarbeat*

## Summary by Sourcery

Bug Fixes:
- Address an ESLint unused variable warning in the PDFProcessor cleanupFailedLoad catch block without changing runtime behavior.