### PR TITLE
🧹 [code health improvement] Remove unused catch block parameter in PDFProcessor

### DIFF
--- a/src/services/PDFProcessor.js
+++ b/src/services/PDFProcessor.js
@@ -352,7 +352,7 @@ export class PDFProcessor extends MediaProcessor {
    * Clean up resources
    */
   cleanup() {
-    this.loadingTask?.destroy().catch((_error) => {});
+    this.loadingTask?.destroy().catch(() => {});
     this.loadingTask = null;
     if (this.pdf) {
       this.pdf.destroy();


### PR DESCRIPTION
🎯 **What:** Removed unused `_error` parameter from the `.catch()` block in `PDFProcessor.js`'s `cleanup()` method.
💡 **Why:** Simplifies the code by removing an unused variable, which satisfies ESLint without needing a placeholder/dummy parameter.
✅ **Verification:** Ran `npx eslint src/services/PDFProcessor.js` (passed with 0 errors) and the full test suite via `pnpm test` (all PDFProcessor unit tests passed).
✨ **Result:** Cleaner code and no unused variables.

---
*PR created automatically by Jules for task [4082442966247370824](https://jules.google.com/task/4082442966247370824) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Remove the unused error parameter from the PDFProcessor cleanup catch block to satisfy linting and reduce noise.