### PR TITLE
🧹 Fix unused catch block error variable in PDFProcessor

### DIFF
--- a/src/services/PDFProcessor.js
+++ b/src/services/PDFProcessor.js
@@ -108,8 +108,8 @@ export class PDFProcessor extends MediaProcessor {
         timeoutId = setTimeout(async () => {
           try {
             await this.loadingTask?.destroy();
-          } catch (destroyError) {
-            void destroyError;
+          } catch (_e) {
+            void _e;
           }
           reject(new Error('PDF loading timed out'));
         }, 60000);


### PR DESCRIPTION
🎯 **What:** Renamed the catch block error variable `destroyError` to `_e` and updated the `void` expression accordingly in `src/services/PDFProcessor.js`.
💡 **Why:** This resolves a minor code health issue by marking the error variable as intentionally unused according to the codebase convention, satisfying linting rules like `no-unused-vars` and `no-empty` while handling the edge case properly.
✅ **Verification:** Verified by running `pnpm lint src/services/PDFProcessor.js` which now passes successfully, and `pnpm test` confirms that no existing functionality is broken.
✨ **Result:** Improved maintainability and codebase cleanliness by addressing lint warnings without altering runtime behavior.

---
*PR created automatically by Jules for task [2743685372489827581](https://jules.google.com/task/2743685372489827581) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Align PDFProcessor timeout error handling with codebase conventions by marking the caught error as intentionally unused.