### PR TITLE
🧪 Add unit tests for config.js utilities

### DIFF
--- a/tests/unit/config.spec.js
+++ b/tests/unit/config.spec.js
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import {
+    toMm,
+    fromMm,
+    formatDimension,
+    resolvePaperSize,
+} from '../../src/utils/config.js';
+
+test.describe('Config Utilities', () => {
+
+    test.describe('toMm', () => {
+        test('converts inches to mm correctly', () => {
+            expect(toMm(1, 'in')).toBe(25.4);
+            expect(toMm('2', 'in')).toBe(50.8);
+        });
+
+        test('returns same value for mm', () => {
+            expect(toMm(10, 'mm')).toBe(10);
+            expect(toMm('15.5', 'mm')).toBe(15.5);
+        });
+
+        test('returns 0 for non-numeric or falsy values', () => {
+            expect(toMm('abc', 'in')).toBe(0);
+            expect(toMm(null, 'mm')).toBe(0);
+            expect(toMm(undefined, 'in')).toBe(0);
+            expect(toMm(NaN, 'mm')).toBe(0);
+        });
+    });
+
+    test.describe('fromMm', () => {
+        test('converts mm to inches correctly', () => {
+            expect(fromMm(25.4, 'in')).toBe(1);
+            expect(fromMm('50.8', 'in')).toBe(2);
+        });
+
+        test('returns same value for mm', () => {
+            expect(fromMm(10, 'mm')).toBe(10);
+            expect(fromMm('15.5', 'mm')).toBe(15.5);
+        });
+
+        test('returns 0 for non-numeric or falsy values', () => {
+            expect(fromMm('abc', 'in')).toBe(0);
+            expect(fromMm(null, 'mm')).toBe(0);
+            expect(fromMm(undefined, 'in')).toBe(0);
+            expect(fromMm(NaN, 'mm')).toBe(0);
+        });
+    });
+
+    test.describe('formatDimension', () => {
+        test('formats in inches with 2 decimals', () => {
+            expect(formatDimension(25.4, 'in')).toBe('1');
+            expect(formatDimension(25.4 * 1.5, 'in')).toBe('1.5');
+            // 25.4 * 1.555 = 39.497. 1.555 rounding can be 1.56
+            expect(formatDimension(39.497, 'in')).toBe('1.56');
+        });
+
+        test('formats in mm with 0 decimals', () => {
+            expect(formatDimension(10.4, 'mm')).toBe('10');
+            expect(formatDimension(10.5, 'mm')).toBe('11');
+            expect(formatDimension(10.6, 'mm')).toBe('11');
+        });
+
+        test('falls back to mm for unknown unit', () => {
+            expect(formatDimension(10.5, 'unknown')).toBe('11');
+        });
+    });
+
+    test.describe('resolvePaperSize', () => {
+        test('resolves known paper sizes', () => {
+            expect(resolvePaperSize('a4')).toEqual({ label: 'A4', width: 210, height: 297 });
+            expect(resolvePaperSize('letter')).toEqual({ label: 'Letter', width: 215.9, height: 279.4 });
+        });
+
+        test('falls back to letter for unknown paper sizes', () => {
+            expect(resolvePaperSize('unknown_size')).toEqual({ label: 'Letter', width: 215.9, height: 279.4 });
+        });
+
+        test('resolves valid custom paper size', () => {
+            const customPaper = { width: 100, height: 150 };
+            expect(resolvePaperSize('custom', customPaper)).toEqual({
+                label: 'Custom',
+                width: 100,
+                height: 150
+            });
+        });
+
+        test('falls back to letter if custom paper is missing or invalid', () => {
+            expect(resolvePaperSize('custom', null)).toEqual({ label: 'Letter', width: 215.9, height: 279.4 });
+            expect(resolvePaperSize('custom', { width: 0, height: 100 })).toEqual({ label: 'Letter', width: 215.9, height: 279.4 });
+            expect(resolvePaperSize('custom', { width: 100, height: -5 })).toEqual({ label: 'Letter', width: 215.9, height: 279.4 });
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** 
Added a missing unit test suite for the pure utility functions exported by `src/utils/config.js` (`toMm`, `fromMm`, `formatDimension`, and `resolvePaperSize`).

📊 **Coverage:**
The new test file (`tests/unit/config.spec.js`) comprehensively covers:
* `toMm`: Valid values in both 'in' and 'mm', string casting, and graceful fallback to `0` for non-numeric/NaN inputs.
* `fromMm`: Conversion math from internal mm to display inches, identity mapping for mm, and error boundary behaviors.
* `formatDimension`: Decimal rounding specific to the configured unit (2 decimals for 'in', 0 for 'mm'), and handling of unknown unit string fallbacks.
* `resolvePaperSize`: Resolution mapping for standard paper sizes (A4, Letter), invalid size string fallbacks, and validation logic for parsing `custom` dimensions (ignoring missing or negative bounds).

✨ **Result:**
Test coverage and reliability for critical configuration mapping math is improved, ensuring future refactoring won't silently break paper dimensions. Tests have been successfully verified against the Playwright unit test suite and passed static analysis.

---
*PR created automatically by Jules for task [10267788317597117124](https://jules.google.com/task/10267788317597117124) started by @guitarbeat*

## Summary by Sourcery

Add a new unit test suite for configuration utilities to ensure correct dimension conversions and paper size resolution.

Tests:
- Introduce Playwright-based unit tests for toMm and fromMm conversion utilities, including handling of invalid inputs.
- Add tests for formatDimension to verify unit-specific rounding behavior and fallbacks for unknown units.
- Add tests for resolvePaperSize covering standard sizes, custom size validation, and fallbacks for invalid or unknown inputs.