### PR TITLE
🧹 Fix: Remove unused eslint-disable comment in FormValidationService

### DIFF
--- a/src/services/FormValidationService.js
+++ b/src/services/FormValidationService.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Validation integration for Zine-ify form controls
  * Demonstrates user-friendly validation for existing settings
@@ -19,6 +18,7 @@ import DOMPurify from 'dompurify';
 export function initSettingsValidation(container = document) {
   const form = container.querySelector('#settings-group') || container.querySelector('.rail-settings-panel');
   if (!form) {
+    /* eslint-disable-next-line no-console */
     console.warn('ValidationService: Settings form not found');
     return null;
   }


### PR DESCRIPTION
🎯 **What:** Removed the `/* eslint-disable */` comment from the top of `src/services/FormValidationService.js` and addressed the resulting `no-console` warning on line 21 by adding `/* eslint-disable-next-line no-console */` for the expected `console.warn` statement.

💡 **Why:** Having file-wide eslint-disable comments hides potential issues and reduces code maintainability. Resolving the specific warnings and removing the global disable ensures the file is linted properly moving forward.

✅ **Verification:** Verified by running `pnpm lint`, which now successfully lints the file without errors, and running `pnpm test` (including the specific form validator component tests).

✨ **Result:** The code health of `src/services/FormValidationService.js` is improved, making it safer to maintain and adhering to standard linting rules.

---
*PR created automatically by Jules for task [713186582730575423](https://jules.google.com/task/713186582730575423) started by @guitarbeat*

## Summary by Sourcery

Enhancements:
- Improve linting hygiene in FormValidationService by eliminating file-wide ESLint disabling in favor of scoped rule suppression.