### PR TITLE
🧪 Add unit tests for sanitizeHTML

### DIFF
--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -1,5 +1,7 @@
+import { JSDOM } from 'jsdom';
+import DOMPurify from 'dompurify';
 import { test, expect } from '@playwright/test';
-import { clampNumber, formatFileSize, isNumber, debounce, parseBoundedInteger, resizeAndFillArray } from '../../src/utils/helpers.js';
+import { clampNumber, formatFileSize, isNumber, debounce, parseBoundedInteger, resizeAndFillArray, sanitizeHTML } from '../../src/utils/helpers.js';
 import {
   classifyFileKind,
   getFileTypeLabel,
@@ -8,6 +10,16 @@ import {
 } from '../../src/utils/fileValidation.js';
 
 test.describe('Utils', () => {
+  test.beforeAll(() => {
+    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.HTMLElement = dom.window.HTMLElement;
+
+    const purify = DOMPurify(global.window);
+    DOMPurify.sanitize = purify.sanitize;
+  });
+
   test('formatFileSize', () => {
     expect(formatFileSize(0)).toBe('0 B');
     expect(formatFileSize(1024)).toBe('1.0 KB');
@@ -120,6 +132,44 @@ test.describe('Utils', () => {
       acceptedFiles: [],
       rejectedFiles: edgeCases
     });
+  });
+
+
+  test('sanitizeHTML', () => {
+    // Non-string or empty input
+    let result = sanitizeHTML(null);
+    expect(result.nodeType).toBe(11); // DocumentFragment
+    expect(result.childNodes.length).toBe(0);
+
+    result = sanitizeHTML('');
+    expect(result.nodeType).toBe(11);
+    expect(result.childNodes.length).toBe(0);
+
+    result = sanitizeHTML(123);
+    expect(result.nodeType).toBe(11);
+    expect(result.childNodes.length).toBe(0);
+
+    // Sanitizes HTML and returns a DocumentFragment with allowed tags
+    const input = '<b>Bold</b> and <em>italic</em> with <script>alert(1)</script>';
+    result = sanitizeHTML(input);
+    expect(result.nodeType).toBe(11);
+    const div = document.createElement('div');
+    div.appendChild(result);
+    expect(div.innerHTML).toBe('<b>Bold</b> and <em>italic</em> with ');
+
+    // Removes disallowed tags but keeps text content
+    const input2 = '<div>Div content</div><span>Span content</span>';
+    result = sanitizeHTML(input2);
+    const div2 = document.createElement('div');
+    div2.appendChild(result);
+    expect(div2.innerHTML).toBe('Div content<span>Span content</span>');
+
+    // Handles complex nested allowed tags
+    const input3 = '<b><strong><i><em><u><br><code><span>text</span></code></u></em></i></strong></b>';
+    result = sanitizeHTML(input3);
+    const div3 = document.createElement('div');
+    div3.appendChild(result);
+    expect(div3.innerHTML).toBe('<b><strong><i><em><u><br><code><span>text</span></code></u></em></i></strong></b>');
   });
 
   test('resizeAndFillArray', () => {


### PR DESCRIPTION
🎯 **What:**
Added comprehensive unit tests for the previously untested `sanitizeHTML` utility function in `src/utils/helpers.js`. 

📊 **Coverage:**
The tests mock the required DOM using `JSDOM` and cover:
*   Invalid or empty inputs returning empty `DocumentFragment` instances.
*   Preservation of safe, allowed tags (`<b>`, `<em>`, `<code>`, etc.) and their nested structures.
*   Correct filtering of disallowed tags (like `<script>`).
*   Retention of safe text content when disallowed wrapping tags (like `<div>` or `<span>`) are stripped.

✨ **Result:**
Test coverage and confidence for the `sanitizeHTML` function are significantly improved, reducing the risk of regressions in critical HTML sanitization logic.

---
*PR created automatically by Jules for task [17283921654949803771](https://jules.google.com/task/17283921654949803771) started by @guitarbeat*

## Summary by Sourcery

Add unit tests for the sanitizeHTML utility and set up a DOMPurify/JSDOM environment in the utils test suite.

Tests:
- Introduce comprehensive sanitizeHTML tests covering invalid inputs, allowed tags, disallowed tags, and nested structures.
- Initialize a JSDOM-based DOM and wire DOMPurify into the global context for HTML sanitization tests.