### PR TITLE
🧪 Add unit tests for error paths in AppController

### DIFF
--- a/tests/unit/app_controller.spec.js
+++ b/tests/unit/app_controller.spec.js
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+import { JSDOM } from 'jsdom';
+
+// Setup JSDOM
+const dom = new JSDOM('<!DOCTYPE html><html><body><div id="toast-container"></div></body></html>', {
+    url: "http://localhost"
+});
+global.window = dom.window;
+global.document = dom.window.document;
+global.requestAnimationFrame = (cb) => cb();
+global.HTMLElement = dom.window.HTMLElement;
+global.Element = dom.window.Element;
+global.Event = dom.window.Event;
+global.CustomEvent = dom.window.CustomEvent;
+
+let AppController;
+let toast;
+
+test.describe('AppController', () => {
+    test.beforeAll(async () => {
+        const mod = await import('../../src/core/AppController.js');
+        AppController = mod.AppController;
+        const toastMod = await import('../../src/components/Toast.js');
+        toast = toastMod.toast;
+    });
+
+  test('processFileQueue handles file upload processing error correctly', async () => {
+    const app = Object.create(AppController.prototype);
+
+    // Mock required state and UI
+    const mockRecord = { name: 'test.jpg', kind: 'image' };
+    app.state = {
+      isProcessingQueue: false,
+      fileQueue: [mockRecord],
+      uploadedFiles: []
+    };
+
+    let setStatusArgs = null;
+    let showProgressCalledWith = null;
+
+    app.ui = {
+      setStatus: (msg, type) => { setStatusArgs = { msg, type }; },
+      modal: {
+        showProgress: (val) => { showProgressCalledWith = val; }
+      },
+      updateUploadedFilesList: () => {}
+    };
+
+    app.updateUploadedFileRecord = function(record, updates) {
+      Object.assign(record, updates);
+    };
+
+    let toastErrorArgs = null;
+    toast.error = (title, message) => {
+      toastErrorArgs = { title, message };
+    };
+
+    app.processImageUpload = async () => {
+      throw new Error('Test image upload error');
+    };
+
+    await app.processFileQueue();
+
+    expect(mockRecord.status).toBe('Failed');
+    expect(setStatusArgs).toEqual({ msg: 'Failed: test.jpg', type: 'error' });
+    expect(toastErrorArgs).toEqual({ title: 'Import Failed', message: 'Test image upload error' });
+    expect(showProgressCalledWith).toBe(false);
+    expect(app.state.isProcessingQueue).toBe(false);
+  });
+
+  test('processFileQueue handles processPdfUpload error correctly', async () => {
+    const app = Object.create(AppController.prototype);
+    const mockRecord = { name: 'test.pdf', kind: 'pdf', status: 'Pending' };
+    app.state = {
+      isProcessingQueue: false,
+      fileQueue: [mockRecord],
+      uploadedFiles: []
+    };
+
+    app.updateUploadedFileRecord = function(record, updates) {
+      Object.assign(record, updates);
+    };
+
+    let setStatusArgs = null;
+    let showProgressCalledWith = null;
+
+    app.ui = {
+      setStatus: (msg, type) => { setStatusArgs = { msg, type }; },
+      modal: {
+        showProgress: (val) => { showProgressCalledWith = val; }
+      },
+      updateUploadedFilesList: () => {}
+    };
+
+    let toastErrorArgs = null;
+    toast.error = (title, message) => {
+      toastErrorArgs = { title, message };
+    };
+
+    app.processPdfUpload = async () => {
+      throw new Error('Test pdf upload error');
+    };
+
+    await app.processFileQueue();
+
+    expect(mockRecord.status).toBe('Failed');
+    expect(setStatusArgs).toEqual({ msg: 'Failed: test.pdf', type: 'error' });
+    expect(toastErrorArgs).toEqual({ title: 'Import Failed', message: 'Test pdf upload error' });
+    expect(showProgressCalledWith).toBe(false);
+    expect(app.state.isProcessingQueue).toBe(false);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added missing error path tests for file upload processing in `AppController.processFileQueue`.
📊 **Coverage:** Covered the error scenarios for image upload (`processImageUpload` throws error) and PDF upload (`processPdfUpload` throws error) and validated state updates and UI toast displays.
✨ **Result:** Improved test coverage and reliability for AppController edge cases.

---
*PR created automatically by Jules for task [9112357405395781756](https://jules.google.com/task/9112357405395781756) started by @guitarbeat*

## Summary by Sourcery

Add unit tests covering error handling in AppController file upload processing for image and PDF files.

Tests:
- Introduce unit tests that verify processFileQueue correctly updates state, UI status, and toast errors when image uploads fail.
- Add unit tests that verify processFileQueue correctly handles PDF upload failures, including status updates and progress modal state.