### PR TITLE
🧪 [Testing Improvement] Add AppController initialization error test

### DIFF
--- a/tests/unit/app_controller.spec.js
+++ b/tests/unit/app_controller.spec.js
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('AppController', () => {
+  let originalInitialize;
+  let originalToastError;
+  let originalConsoleError;
+
+  test.beforeEach(async () => {
+    // Need JSDOM since Toast evaluates `document` at top-level execution
+    const { JSDOM } = await import('jsdom');
+    const dom = new JSDOM('<!DOCTYPE html><html lang="en"><body><div id="toast-container"></div></body></html>', {
+      url: 'http://localhost/'
+    });
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.HTMLElement = dom.window.HTMLElement;
+    global.localStorage = dom.window.localStorage;
+    global.window.matchMedia = () => ({ matches: false, addEventListener: () => {} });
+  });
+
+  test.afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.HTMLElement;
+    delete global.localStorage;
+  });
+
+  test('init handles pdfProcessor.initialize error correctly', async () => {
+    // Import modules dynamically after jsdom is set
+    const { AppController } = await import('../../src/core/AppController.js');
+    const { toast } = await import('../../src/components/Toast.js');
+    const { PDFProcessor } = await import('../../src/services/PDFProcessor.js');
+
+    let toastErrorTitle = null;
+    let toastErrorMessage = null;
+    originalToastError = toast.error;
+    toast.error = (title, message) => {
+      toastErrorTitle = title;
+      toastErrorMessage = message;
+    };
+
+    let consoleErrorMsg = null;
+    // eslint-disable-next-line no-console
+    originalConsoleError = console.error;
+    // eslint-disable-next-line no-console
+    console.error = (msg) => {
+        consoleErrorMsg = msg;
+    };
+
+    originalInitialize = PDFProcessor.prototype.initialize;
+    PDFProcessor.prototype.initialize = async () => {
+      throw new Error('Mock PDF initialization failure');
+    };
+
+    try {
+      const controller = new AppController();
+
+      // wait for the catch block to execute.
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(toastErrorTitle).toBe('Initialization Failed');
+      expect(toastErrorMessage).toBe('Check console for details.');
+      expect(consoleErrorMsg).toBe('Mock PDF initialization failure');
+      expect(controller).toBeDefined();
+    } finally {
+      // restore
+      PDFProcessor.prototype.initialize = originalInitialize;
+      toast.error = originalToastError;
+      // eslint-disable-next-line no-console
+      console.error = originalConsoleError;
+    }
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added a missing error path test for `AppController.init()` to ensure that if `pdfProcessor.initialize()` throws an error, it is properly caught and `toast.error` is triggered.

📊 **Coverage:** Specifically covers the initialization failure scenario in `AppController.js`, mocking `pdfProcessor.initialize()` to throw an error and verifying the subsequent `toast.error` and `console.error` calls.

✨ **Result:** Improved test coverage and reliability for application startup error handling.

---
*PR created automatically by Jules for task [12130702171040902462](https://jules.google.com/task/12130702171040902462) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add Playwright-based unit test for AppController.init() to cover pdfProcessor.initialize() error handling and verify toast.error and console.error behavior.