### PR TITLE
🧹 Remove unused .sheet-cut-line-label--unused CSS class

### DIFF
--- a/src/styles/zine-editor.css
+++ b/src/styles/zine-editor.css
@@ -400,25 +400,6 @@
 .sheet-cut-line::before { left: 0; }
 .sheet-cut-line::after  { right: 0; }
 
-.sheet-cut-line-label--unused {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  background: var(--primary-vibrant);
-  color: var(--accent-dark);
-  font-size: 0.55rem;
-  font-weight: 900;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  padding: 0.15rem 0.5rem;
-  border-radius: 2px;
-  border: 1px solid var(--border-color);
-  white-space: nowrap;
-  font-family: 'Comic Sans MS', 'Courier New', monospace;
-  box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.2);
-  z-index: 15;
-}
 
 /* ── Drag-to-reorder live preview ─────────────────── */
 .drag-drop-preview {


### PR DESCRIPTION
🎯 **What:** Removed the unused `.sheet-cut-line-label--unused` CSS class block from `src/styles/zine-editor.css`.

💡 **Why:** The class was identified as dead code and was not referenced anywhere in the project (verified via `grep`). Removing dead code cleans up the CSS bundle, improves maintainability, and makes the codebase easier to read by reducing unnecessary noise.

✅ **Verification:** 
- Inspected the removed block in `src/styles/zine-editor.css` to confirm no adjacent styles were broken.
- Ran `pnpm lint` and `pnpm test` to verify no formatting errors or functionality regressions were introduced.

✨ **Result:** A cleaner CSS file with no dead code, without affecting any existing behavior.

---
*PR created automatically by Jules for task [18297166241286180103](https://jules.google.com/task/18297166241286180103) started by @guitarbeat*

## Summary by Sourcery

Remove an unused CSS class from the zine editor styles to reduce dead code and simplify the stylesheet.