### PR TITLE
🧹 [code health improvement] Fix unused eslint-disable comment in FormValidator.js

### DIFF
--- a/src/components/FormValidator.js
+++ b/src/components/FormValidator.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * FormValidator.js
  * Inline form validation with immediate visual feedback
@@ -26,6 +25,7 @@ export class FormValidator {
       : formElement;
 
     if (!this.form) {
+      // eslint-disable-next-line no-console
       console.error('FormValidator: Form element not found');
       return;
     }
@@ -64,6 +64,7 @@ export class FormValidator {
   register(fieldSelector, config) {
     const field = this.form.querySelector(fieldSelector);
     if (!field) {
+      // eslint-disable-next-line no-console
       console.warn(`FormValidator: Field "${fieldSelector}" not found`);
       return this;
     }
@@ -534,6 +535,7 @@ export class FieldValidator {
       : field;
 
     if (!this.field) {
+      // eslint-disable-next-line no-console
       console.error('FieldValidator: Field element not found');
       return;
     }


### PR DESCRIPTION
🎯 **What:** Removed the global `/* eslint-disable */` comment in `src/components/FormValidator.js` and addressed the resulting `no-console` linting warnings by adding specific `// eslint-disable-next-line no-console` comments where intended log statements occur.

💡 **Why:** Having a global `/* eslint-disable */` is a bad practice as it masks potential genuine linting issues. Specifically addressing the necessary console statements allows the rest of the file to benefit from linting without removing the diagnostic logging.

✅ **Verification:** Verified by running `npx eslint src/components/FormValidator.js` and `pnpm test` (with no new test failures).

✨ **Result:** The code now conforms to the project's linting standards for the rest of the file, improving overall maintainability.

---
*PR created automatically by Jules for task [15601662967936615243](https://jules.google.com/task/15601662967936615243) started by @guitarbeat*

## Summary by Sourcery

Tighten linting in FormValidator by removing the global eslint-disable and scoping exceptions to intended console logging.

Enhancements:
- Remove the file-wide eslint-disable directive from FormValidator to re-enable lint checks.
- Add targeted no-console suppression comments on specific diagnostic console calls in form and field validation.