### PR TITLE
🧪 [Testing] Add tests for DragAndDropHandler

### DIFF
--- a/src/components/UI/UIManager.js
+++ b/src/components/UI/UIManager.js
@@ -552,13 +552,6 @@ export class UIManager {
       });
     });
 
-    const stepButtonMap = new Map();
-    this.elements.foldStepButtons?.forEach((button) => {
-      if (button.dataset.stepIndex) {
-        stepButtonMap.set(button.dataset.stepIndex, button);
-      }
-    });
-
     document.addEventListener('keydown', (event) => {
       if (!this.isFoldPreviewOpen() || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
         return;

--- a/tests/unit/components/drag_and_drop_handler.spec.js
+++ b/tests/unit/components/drag_and_drop_handler.spec.js
@@ -1,0 +1,287 @@
+import { test, expect } from '@playwright/test';
+import { JSDOM } from 'jsdom';
+
+test.describe('DragAndDropHandler', () => {
+  let DragAndDropHandler;
+  let dom;
+  let emitter;
+  let elements;
+  let emitCalls = [];
+
+  test.beforeAll(async () => {
+    dom = new JSDOM('<!DOCTYPE html><body></body>', { url: 'http://localhost/' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    // global.navigator = dom.window.navigator;
+    global.HTMLElement = dom.window.HTMLElement;
+
+    const module = await import('../../../src/components/UI/DragAndDropHandler.js');
+    DragAndDropHandler = module.DragAndDropHandler;
+  });
+
+  test.afterAll(() => {
+    delete global.window;
+    delete global.document;
+    delete global.navigator;
+    delete global.HTMLElement;
+  });
+
+  test.beforeEach(() => {
+    document.body.innerHTML = '<div id="unified-drop-zone"></div>';
+
+    elements = {
+      uploadZone: document.createElement('div')
+    };
+
+    emitCalls = [];
+    emitter = {
+      emit: (event, data) => emitCalls.push({ event, data })
+    };
+  });
+
+  test('initializes properties correctly', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    expect(handler.elements).toBe(elements);
+    expect(handler.emitter).toBe(emitter);
+    expect(handler._sortables).toEqual([]);
+  });
+
+  test('setupEventListeners handles uploadZone dragover', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    handler.setupEventListeners();
+
+    const dragoverEvent = new dom.window.Event('dragover');
+    let preventDefaultCalled = false;
+    dragoverEvent.preventDefault = () => { preventDefaultCalled = true; };
+
+    elements.uploadZone.dispatchEvent(dragoverEvent);
+
+    expect(preventDefaultCalled).toBe(true);
+    expect(elements.uploadZone.classList.contains('dragover')).toBe(true);
+  });
+
+  test('setupEventListeners handles uploadZone dragleave', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    handler.setupEventListeners();
+
+    elements.uploadZone.classList.add('dragover');
+    elements.uploadZone.dispatchEvent(new dom.window.Event('dragleave'));
+
+    expect(elements.uploadZone.classList.contains('dragover')).toBe(false);
+  });
+
+  test('setupEventListeners handles uploadZone drop', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    handler.setupEventListeners();
+
+    elements.uploadZone.classList.add('dragover');
+    const dropEvent = new dom.window.Event('drop');
+    dropEvent.preventDefault = () => {};
+    dropEvent.dataTransfer = {
+      files: [{ name: 'test.pdf' }]
+    };
+
+    elements.uploadZone.dispatchEvent(dropEvent);
+
+    expect(elements.uploadZone.classList.contains('dragover')).toBe(false);
+    expect(emitCalls.length).toBe(1);
+    expect(emitCalls[0].event).toBe('filesDropped');
+    expect(emitCalls[0].data).toEqual([{ name: 'test.pdf' }]);
+  });
+
+  test('setupEventListeners ignores uploadZone drop with empty files', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    handler.setupEventListeners();
+
+    const dropEvent = new dom.window.Event('drop');
+    dropEvent.preventDefault = () => {};
+    dropEvent.dataTransfer = { files: [] };
+
+    elements.uploadZone.dispatchEvent(dropEvent);
+    expect(emitCalls.length).toBe(0);
+  });
+
+  test('setupEventListeners handles unified-drop-zone dragover', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    handler.setupEventListeners();
+    const zone = document.getElementById('unified-drop-zone');
+
+    const dragoverEvent = new dom.window.Event('dragover');
+    let preventDefaultCalled = false;
+    dragoverEvent.preventDefault = () => { preventDefaultCalled = true; };
+    dragoverEvent.dataTransfer = { types: ['Files'], dropEffect: 'none' };
+
+    zone.dispatchEvent(dragoverEvent);
+
+    expect(preventDefaultCalled).toBe(true);
+    expect(dragoverEvent.dataTransfer.dropEffect).toBe('copy');
+    expect(zone.classList.contains('drag-active')).toBe(true);
+  });
+
+  test('setupEventListeners ignores unified-drop-zone dragover if text/plain is included', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    handler.setupEventListeners();
+    const zone = document.getElementById('unified-drop-zone');
+
+    const dragoverEvent = new dom.window.Event('dragover');
+    let preventDefaultCalled = false;
+    dragoverEvent.preventDefault = () => { preventDefaultCalled = true; };
+    dragoverEvent.dataTransfer = { types: ['text/plain', 'Files'] };
+
+    zone.dispatchEvent(dragoverEvent);
+
+    expect(preventDefaultCalled).toBe(false);
+    expect(zone.classList.contains('drag-active')).toBe(false);
+  });
+
+  test('setupEventListeners handles unified-drop-zone dragleave', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    handler.setupEventListeners();
+    const zone = document.getElementById('unified-drop-zone');
+    zone.classList.add('drag-active');
+
+    const dragleaveEvent = new dom.window.Event('dragleave');
+    // Not related target inside the zone
+    dragleaveEvent.relatedTarget = document.body;
+
+    zone.dispatchEvent(dragleaveEvent);
+
+    expect(zone.classList.contains('drag-active')).toBe(false);
+  });
+
+  test('setupEventListeners does not remove drag-active on dragleave if relatedTarget is inside', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    handler.setupEventListeners();
+    const zone = document.getElementById('unified-drop-zone');
+    const child = document.createElement('div');
+    zone.appendChild(child);
+    zone.classList.add('drag-active');
+
+    const dragleaveEvent = new dom.window.Event('dragleave');
+    dragleaveEvent.relatedTarget = child;
+
+    zone.dispatchEvent(dragleaveEvent);
+
+    expect(zone.classList.contains('drag-active')).toBe(true);
+  });
+
+  test('setupEventListeners handles unified-drop-zone drop', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    handler.setupEventListeners();
+    const zone = document.getElementById('unified-drop-zone');
+    zone.classList.add('drag-active');
+
+    const dropEvent = new dom.window.Event('drop');
+    let preventDefaultCalled = false;
+    dropEvent.preventDefault = () => { preventDefaultCalled = true; };
+    dropEvent.dataTransfer = { files: [{ name: 'external.pdf' }] };
+
+    zone.dispatchEvent(dropEvent);
+
+    expect(zone.classList.contains('drag-active')).toBe(false);
+    expect(preventDefaultCalled).toBe(true);
+    expect(emitCalls.length).toBe(1);
+    expect(emitCalls[0].event).toBe('filesDropped');
+    expect(emitCalls[0].data).toEqual([{ name: 'external.pdf' }]);
+  });
+
+  test('initSortable returns early if no gridEl provided', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    const s = handler.initSortable(null);
+    expect(s).toBeUndefined();
+    expect(handler._sortables.length).toBe(0);
+  });
+
+  test('initSortable sets up Sortable and triggers onStart, onMove, onEnd events properly', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    const gridEl = document.createElement('div');
+    const s = handler.initSortable(gridEl);
+
+    expect(s).toBeDefined();
+    expect(handler._sortables.length).toBe(1);
+    expect(handler._sortables[0]).toBe(s);
+
+    expect(s.options.animation).toBe(160);
+
+    // Test onStart
+    const item = document.createElement('div');
+    item.dataset.pageIndex = '1';
+    s.options.onStart({ item });
+
+    // Test onMove to another cell
+    const rel = document.createElement('div');
+    rel.classList.add('page-cell');
+    rel.dataset.pageIndex = '3';
+    const moveResult = s.options.onMove({ related: rel });
+    expect(moveResult).toBe(true);
+
+    // Test onEnd
+    s.options.onEnd();
+
+    expect(emitCalls.length).toBe(1);
+    expect(emitCalls[0].event).toBe('pagesSwapped');
+    expect(emitCalls[0].data).toEqual({ fromIndex: 1, toIndex: 3 });
+  });
+
+  test('initSortable onMove ignores non-page-cells', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    const gridEl = document.createElement('div');
+    const s = handler.initSortable(gridEl);
+
+    const item = document.createElement('div');
+    item.dataset.pageIndex = '1';
+    s.options.onStart({ item });
+
+    // Move to something that is NOT a page-cell
+    const rel = document.createElement('div');
+    s.options.onMove({ related: rel });
+
+    s.options.onEnd();
+
+    // Should NOT emit since targetPageIndex would be null
+    expect(emitCalls.length).toBe(0);
+  });
+
+  test('initSortable onEnd does not emit if fromIndex and toIndex are same', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    const gridEl = document.createElement('div');
+    const s = handler.initSortable(gridEl);
+
+    const item = document.createElement('div');
+    item.dataset.pageIndex = '2';
+    s.options.onStart({ item });
+
+    const rel = document.createElement('div');
+    rel.classList.add('page-cell');
+    rel.dataset.pageIndex = '2'; // Same index
+    s.options.onMove({ related: rel });
+
+    s.options.onEnd();
+
+    expect(emitCalls.length).toBe(0);
+  });
+
+  test('destroySortables destroys all tracked sortables', () => {
+    const handler = new DragAndDropHandler(elements, emitter);
+    const gridEl1 = document.createElement('div');
+    const gridEl2 = document.createElement('div');
+
+    const s1 = handler.initSortable(gridEl1);
+    const s2 = handler.initSortable(gridEl2);
+
+    expect(handler._sortables.length).toBe(2);
+
+    let destroy1Called = false;
+    let destroy2Called = false;
+
+    // Override destroy method to test it's being called
+    s1.destroy = () => { destroy1Called = true; };
+    s2.destroy = () => { destroy2Called = true; };
+
+    handler.destroySortables();
+
+    expect(destroy1Called).toBe(true);
+    expect(destroy2Called).toBe(true);
+    expect(handler._sortables.length).toBe(0);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Adds unit tests for the `DragAndDropHandler` class located at `src/components/UI/DragAndDropHandler.js`. The class had missing test coverage.

📊 **Coverage:** 
- Proper instantiation of handler properties (`elements`, `emitter`, `_sortables`).
- Events handled on the `uploadZone` element: `dragover`, `dragleave`, `drop` (both valid files and empty ones).
- Events handled on the `unified-drop-zone` element: `dragover`, `dragleave`, `drop`, and edge case ignoring drag events with `text/plain` types.
- The Sortable setup using `initSortable()` and the expected Sortable options correctly interacting with simulated `.page-cell` interactions triggering Sortable `onMove`, `onEnd`, and emitting `pagesSwapped` payloads.
- Verifies the `destroySortables()` method properly iterates and triggers `destroy` on `Sortable` instances.

✨ **Result:** Test coverage for this logic module increased to fully cover event attachments and external drag-n-drop event triggers within the Grid functionality.

---
*PR created automatically by Jules for task [11503712087741302424](https://jules.google.com/task/11503712087741302424) started by @guitarbeat*

## Summary by Sourcery

Add unit test coverage for DragAndDropHandler drag-and-drop behavior and sortable interactions.

Enhancements:
- Remove unused fold step button mapping logic from UIManager to simplify the code.

Tests:
- Add Playwright/JSDOM-based unit tests covering DragAndDropHandler upload zone and unified-drop-zone drag/drop events, file handling, and Sortable-based page swapping.
- Verify Sortable initialization, event callbacks, and destruction logic for grid elements.