### PR TITLE
Merge Display panel into Settings and compact styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,13 +123,13 @@
 
                 <!-- ── PANEL: Page settings ──────────────────────────── -->
                 <div class="grid-stack-item"
-                    gs-id="settings" gs-x="9" gs-y="7" gs-w="3" gs-h="4"
+                    gs-id="settings" gs-x="9" gs-y="7" gs-w="3" gs-h="6"
                     gs-min-w="2" gs-min-h="2" gs-size-to-content="true">
                     <div class="grid-stack-item-content">
                         <div class="snap-card" id="card-settings">
                             <div class="snap-card-handle" title="Drag to move">
                                 <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
-                                <span class="snap-card-label">Paper</span>
+                                <span class="snap-card-label">Settings</span>
                             </div>
                             <div class="snap-card-body">
                                 <section id="settings-group">
@@ -137,38 +137,38 @@
                                     <input type="hidden" id="paper-size-select" value="letter">
                                     <input type="hidden" id="orientation-toggle" value="landscape">
                                 </section>
+                                <hr class="workspace-config-divider">
+                                <section id="display-group">
+                                    <p class="workspace-config-group-label">Display</p>
+                                    <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-numbers">
+                                        <span class="workspace-config-toggle-copy">Page Numbers</span>
+                                        <input type="checkbox" id="show-page-numbers" checked class="workspace-config-toggle-input">
+                                        <span class="workspace-config-toggle-switch" aria-hidden="true">
+                                            <span class="workspace-config-toggle-knob"></span>
+                                        </span>
+                                    </label>
+                                    <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-controls">
+                                        <span class="workspace-config-toggle-copy">Page Controls</span>
+                                        <input type="checkbox" id="show-page-controls" checked class="workspace-config-toggle-input">
+                                        <span class="workspace-config-toggle-switch" aria-hidden="true">
+                                            <span class="workspace-config-toggle-knob"></span>
+                                        </span>
+                                    </label>
+                                    <p class="workspace-config-hint">Preview only — won't print.</p>
+                                </section>
                             </div>
                         </div>
                     </div>
                 </div>
 
                 <!-- ── PANEL: Display options ────────────────────────── -->
+                <!-- Merged into Settings panel above -->
                 <div class="grid-stack-item"
                     gs-id="display" gs-x="9" gs-y="11" gs-w="3" gs-h="2"
-                    gs-min-w="2" gs-min-h="2" gs-size-to-content="true">
+                    gs-min-w="2" gs-min-h="2" gs-size-to-content="true"
+                    style="display: none;">
                     <div class="grid-stack-item-content">
-                        <div class="snap-card" id="card-display">
-                            <div class="snap-card-handle" title="Drag to move">
-                                <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
-                                <span class="snap-card-label">Display</span>
-                            </div>
-                            <div class="snap-card-body snap-card-body--display">
-                                <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-numbers">
-                                    <span class="workspace-config-toggle-copy">Page Numbers</span>
-                                    <input type="checkbox" id="show-page-numbers" checked class="workspace-config-toggle-input">
-                                    <span class="workspace-config-toggle-switch" aria-hidden="true">
-                                        <span class="workspace-config-toggle-knob"></span>
-                                    </span>
-                                </label>
-                                <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-controls">
-                                    <span class="workspace-config-toggle-copy">Page Controls</span>
-                                    <input type="checkbox" id="show-page-controls" checked class="workspace-config-toggle-input">
-                                    <span class="workspace-config-toggle-switch" aria-hidden="true">
-                                        <span class="workspace-config-toggle-knob"></span>
-                                    </span>
-                                </label>
-                                <p class="workspace-config-hint">Preview only — won't print.</p>
-                            </div>
+                        <div class="snap-card" id="card-display" style="display: none;">
                         </div>
                     </div>
                 </div>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -983,7 +983,7 @@ select.is-valid:focus {
 
 .smart-sheet-config {
   display: grid;
-  gap: 1rem;
+  gap: 0.6rem;
 }
 
 .smart-sheet-label {
@@ -996,7 +996,7 @@ select.is-valid:focus {
 
 .smart-sheet-section {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .smart-sheet-header {
@@ -1007,7 +1007,7 @@ select.is-valid:focus {
 }
 
 .smart-sheet-label {
-  font-size: 0.67rem;
+  font-size: 0.62rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -1182,8 +1182,8 @@ select.is-valid:focus {
 }
 
 .smart-sheet-stepper-btn {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1215,7 +1215,7 @@ select.is-valid:focus {
 }
 
 .smart-sheet-value {
-  font-size: 1.1rem;
+  font-size: 0.95rem;
   font-weight: 700;
   color: var(--accent-dark);
   line-height: 1;
@@ -1229,7 +1229,7 @@ select.is-valid:focus {
 }
 
 .smart-sheet-times {
-  font-size: 1.25rem;
+  font-size: 1rem;
   font-weight: 400;
   color: var(--muted-ink);
 }
@@ -1237,9 +1237,9 @@ select.is-valid:focus {
 /* Paper selector */
 .smart-sheet-select {
   width: 100%;
-  min-height: 2.25rem;
-  padding: 0.45rem 2rem 0.45rem 0.7rem;
-  font-size: 0.85rem;
+  min-height: 2rem;
+  padding: 0.35rem 2rem 0.35rem 0.65rem;
+  font-size: 0.8rem;
   font-weight: 500;
   color: var(--accent-dark);
   background: var(--surface-muted);
@@ -1270,8 +1270,8 @@ select.is-valid:focus {
 .smart-sheet-paper-recommend {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  font-size: 0.65rem;
+  gap: 0.2rem;
+  font-size: 0.6rem;
   font-weight: 500;
   color: #16a34a;
   opacity: 0;
@@ -1346,14 +1346,14 @@ select.is-valid:focus {
 /* Margin control */
 .smart-sheet-margin-control {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.25rem;
 }
 
 .smart-sheet-margin-stepper {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
+  gap: 0.15rem;
 }
 
 .smart-sheet-margin-value {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -983,7 +983,7 @@ select.is-valid:focus {
 
 .smart-sheet-config {
   display: grid;
-  gap: 0.6rem;
+  gap: 0.35rem;
 }
 
 .smart-sheet-label {
@@ -996,21 +996,21 @@ select.is-valid:focus {
 
 .smart-sheet-section {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.3rem;
 }
 
 .smart-sheet-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.25rem;
 }
 
 .smart-sheet-label {
-  font-size: 0.62rem;
+  font-size: 0.55rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
   color: var(--muted-ink);
 }
 
@@ -1182,15 +1182,15 @@ select.is-valid:focus {
 }
 
 .smart-sheet-stepper-btn {
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
   background: var(--surface-bg);
   border: 1px solid var(--border-color);
-  border-radius: 0.375rem;
-  font-size: 1rem;
+  border-radius: 0.25rem;
+  font-size: 0.85rem;
   color: var(--muted-ink);
   cursor: pointer;
   transition: all 0.15s ease;
@@ -1215,7 +1215,7 @@ select.is-valid:focus {
 }
 
 .smart-sheet-value {
-  font-size: 0.95rem;
+  font-size: 0.85rem;
   font-weight: 700;
   color: var(--accent-dark);
   line-height: 1;
@@ -1229,7 +1229,7 @@ select.is-valid:focus {
 }
 
 .smart-sheet-times {
-  font-size: 1rem;
+  font-size: 0.85rem;
   font-weight: 400;
   color: var(--muted-ink);
 }
@@ -1237,9 +1237,9 @@ select.is-valid:focus {
 /* Paper selector */
 .smart-sheet-select {
   width: 100%;
-  min-height: 2rem;
-  padding: 0.35rem 2rem 0.35rem 0.65rem;
-  font-size: 0.8rem;
+  min-height: 1.75rem;
+  padding: 0.25rem 2rem 0.25rem 0.5rem;
+  font-size: 0.75rem;
   font-weight: 500;
   color: var(--accent-dark);
   background: var(--surface-muted);
@@ -1270,8 +1270,8 @@ select.is-valid:focus {
 .smart-sheet-paper-recommend {
   display: inline-flex;
   align-items: center;
-  gap: 0.2rem;
-  font-size: 0.6rem;
+  gap: 0.15rem;
+  font-size: 0.55rem;
   font-weight: 500;
   color: #16a34a;
   opacity: 0;
@@ -1283,7 +1283,7 @@ select.is-valid:focus {
 }
 
 .smart-sheet-paper-recommend .material-symbols-outlined {
-  font-size: 14px;
+  font-size: 12px;
 }
 
 /* Orientation buttons */
@@ -1346,21 +1346,21 @@ select.is-valid:focus {
 /* Margin control */
 .smart-sheet-margin-control {
   display: grid;
-  gap: 0.25rem;
+  gap: 0.15rem;
 }
 
 .smart-sheet-margin-stepper {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.15rem;
+  gap: 0.1rem;
 }
 
 .smart-sheet-margin-value {
   display: flex;
   align-items: baseline;
-  gap: 0.15rem;
-  min-width: 36px;
+  gap: 0.08rem;
+  min-width: 32px;
   justify-content: center;
 }
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -217,6 +217,22 @@ input[type="number"].workspace-config-input::-webkit-outer-spin-button {
   margin-top: -0.1rem;
 }
 
+.workspace-config-divider {
+  margin: 0.4rem 0;
+  border: none;
+  border-top: 1px solid var(--border-color);
+}
+
+.workspace-config-group-label {
+  font-size: 0.55rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-ink);
+  margin: 0;
+  padding: 0 0 0.3rem 0;
+}
+
 /* Orientation segmented control */
 .orientation-seg {
   display: flex;


### PR DESCRIPTION
### Summary
Consolidates the Display panel into the Settings panel and tightens up spacing/typography across the smart-sheet config UI for a more compact layout.

### Problem
The workspace had separate "Paper" (settings) and "Display" panels taking up extra screen space with generously sized controls, making the UI feel sprawling and less efficient to use.

### Solution
Merged the Display panel's page number and page control toggles directly into the Settings panel under a new "Display" subsection, and hid the now-redundant standalone Display panel. Reduced font sizes, spacing, and control dimensions throughout the smart-sheet config styles to achieve a denser, more compact appearance.

### Key Changes
- Renamed the Settings panel label from "Paper" to "Settings" and increased its height (`gs-h`) to accommodate the merged content.
- Added a new "Display" section inside the Settings panel with page number and page control toggles, plus a hint text.
- Hid the original standalone Display panel (`card-display`) via inline `display: none` instead of removing it.
- Added `.workspace-config-divider` and `.workspace-config-group-label` styles to visually separate grouped settings sections.
- Reduced gaps, font sizes, padding, and control sizes (steppers, selects, values, margin controls) in `smart-sheet-*` classes for a tighter, more compact panel layout.


---

<a href="https://builder.io/app/projects/a0a0c9b3e62743a89532/silky-border-jdom5gkp"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://a0a0c9b3e62743a89532-silky-border-jdom5gkp.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=a0a0c9b3e62743a89532&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 489`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0a0c9b3e62743a89532</projectId>-->
<!--<branchName>silky-border-jdom5gkp</branchName>-->