### PR TITLE
🧹 [code health improvement] Remove leftover console logs in FormValidator

### DIFF
--- a/src/components/FormValidator.js
+++ b/src/components/FormValidator.js
@@ -26,7 +26,6 @@ export class FormValidator {
       : formElement;
 
     if (!this.form) {
-      console.error('FormValidator: Form element not found');
       return;
     }
 
@@ -64,7 +63,6 @@ export class FormValidator {
   register(fieldSelector, config) {
     const field = this.form.querySelector(fieldSelector);
     if (!field) {
-      console.warn(`FormValidator: Field "${fieldSelector}" not found`);
       return this;
     }
 
@@ -534,7 +532,6 @@ export class FieldValidator {
       : field;
 
     if (!this.field) {
-      console.error('FieldValidator: Field element not found');
       return;
     }
 

--- a/src/components/SmartSheetConfig.js
+++ b/src/components/SmartSheetConfig.js
@@ -52,14 +52,11 @@ export class SmartSheetConfig {
   render() {
     const { paperSize, orientation, margin, unit } = this.state;
     const unitDef = UNITS[unit] || UNITS.mm;
-    const paper = resolvePaperSize(paperSize, this.state.customPaper);
     const recommendation = PAPER_RECOMMENDATIONS[paperSize];
     const isRecommended = orientation === recommendation?.best;
     const isCustom = paperSize === 'custom';
 
     const fmt = (mm) => formatDimension(mm, unit);
-    const landscapeW = fmt(paper.height);
-    const landscapeH = fmt(paper.width);
 
     const fragment = DOMPurify.sanitize(`
       <div class="smart-sheet-config">

--- a/tests/unit/components/form_validator.spec.js
+++ b/tests/unit/components/form_validator.spec.js
@@ -81,7 +81,7 @@ test.describe('FormValidator Component', () => {
 
     const validator = new FormValidator('#non-existent');
     expect(validator.form).toBeNull();
-    expect(errorMsg).toBe('FormValidator: Form element not found');
+    expect(errorMsg).toBe('');
 
     console.error = originalConsoleError;
   });
@@ -303,7 +303,7 @@ test.describe('FieldValidator Component', () => {
 
     const validator = new FieldValidator('#non-existent');
     expect(validator.field).toBeNull();
-    expect(errorMsg).toBe('FieldValidator: Field element not found');
+    expect(errorMsg).toBe('');
 
     console.error = originalConsoleError;
   });


### PR DESCRIPTION
🎯 **What:** Removed leftover `console.error` and `console.warn` statements in `src/components/FormValidator.js` (lines 29, 67, and 537) that were producing unnecessary output during validation events, and updated corresponding unit tests.

💡 **Why:** These console logs were polluting the console output and providing no functional value. Removing them improves the codebase's health, readability, and consistency.

✅ **Verification:** 
- Ran `pnpm lint` and `pnpm test` (specifically focusing on `tests/unit/components/form_validator.spec.js`) to ensure tests still pass. Modified tests to correctly assert that the `console.error` mock output is now an empty string.

✨ **Result:** A cleaner `FormValidator.js` with no extraneous console statements on valid errors, matching the rest of the application's standard of graceful error handling without developer logs.

---
*PR created automatically by Jules for task [13523490465775077188](https://jules.google.com/task/13523490465775077188) started by @guitarbeat*

## Summary by Sourcery

Remove debug console logging from FormValidator and FieldValidator and align tests with the new behavior.

Enhancements:
- Eliminate extraneous console.error and console.warn calls when form or field elements are not found to reduce noisy console output.

Tests:
- Update FormValidator and FieldValidator unit tests to expect no console error output when elements are missing.