### PR TITLE
🧹 [code health improvement: remove leftover console.error]

### DIFF
--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -696,13 +696,11 @@ export class AppController {
           const Zine3DViewer = await this.getZine3DViewerClass();
           try {
             this.viewer3d = new Zine3DViewer(container);
-          } catch (e) {
+          } catch {
             const fallback = container.querySelector('.zine-3d-fallback-canvas');
             if (fallback) {
               fallback.remove();
             }
-            /* eslint-disable-next-line no-console */
-            console.error(e);
             this.viewer3d = null;
             this.ui.toggle3DModal(false);
             toast.error('3D Preview Failed', 'Unable to initialize the fold preview.');


### PR DESCRIPTION
🎯 **What:** Removed leftover `console.error` and its `/* eslint-disable-next-line no-console */` directive in `src/core/AppController.js`, and changed the `catch (e)` to an optional `catch` binding.
💡 **Why:** Leftover console logs pollute the output and are no longer necessary for application logic. Removing them along with the unused error variable improves code cleanliness and maintainability.
✅ **Verification:** Verified by running `pnpm lint` and `pnpm test`. Code review confirmed the changes were safe and in scope.
✨ **Result:** A cleaner codebase with no unused variables or unnecessary console logging.

---
*PR created automatically by Jules for task [9287041457825731490](https://jules.google.com/task/9287041457825731490) started by @guitarbeat*

## Summary by Sourcery

Clean up 3D viewer initialization error handling by removing leftover console logging and unused error binding from AppController.