### PR TITLE
🧪 Add missing test for PDFProcessor image processing failure path

### DIFF
--- a/tests/unit/pdf_processor.spec.js
+++ b/tests/unit/pdf_processor.spec.js
@@ -346,4 +346,19 @@ test.describe('PDFProcessor Media handling', () => {
     expect(closed).toBe(true);
   });
 
+
+  test('renderImageFile throws properly formatted error when image processing fails', async () => {
+    processor.loadImageElement = async () => {
+      throw new Error('Simulated image load failure');
+    };
+
+    if (typeof global !== 'undefined' && !global.URL.createObjectURL) {
+      global.URL.createObjectURL = () => 'blob:test';
+      global.URL.revokeObjectURL = () => {};
+    }
+
+    const file = new File(['fake-image-data'], 'test.png', { type: 'image/png' });
+
+    await expect(processor.renderImageFile(file)).rejects.toThrow('Image processing failed: Simulated image load failure');
+  });
 });


### PR DESCRIPTION
🎯 **What:** The `renderImageFile` method inside `src/services/PDFProcessor.js` had an untested error path where image processing failure formatting is handled inside a `catch` block. This adds a test asserting that error behavior.
📊 **Coverage:** The image loading error rejection path inside `renderImageFile` is now fully tested and asserted against.
✨ **Result:** Test coverage for `PDFProcessor` is now more robust, ensuring the exact error message shape and fallback format continues to correctly fire on failure.

---
*PR created automatically by Jules for task [14332118465840762403](https://jules.google.com/task/14332118465840762403) started by @guitarbeat*

## Summary by Sourcery

Tests:
- Add a unit test verifying renderImageFile rejects with the expected error message when image processing fails.