### PR TITLE
🧹 [code health improvement] Remove commented out validation example

### DIFF
--- a/src/components/SmartSheetConfig.js
+++ b/src/components/SmartSheetConfig.js
@@ -52,15 +52,11 @@ export class SmartSheetConfig {
   render() {
     const { paperSize, orientation, margin, unit } = this.state;
     const unitDef = UNITS[unit] || UNITS.mm;
-    const paper = resolvePaperSize(paperSize, this.state.customPaper);
     const recommendation = PAPER_RECOMMENDATIONS[paperSize];
     const isRecommended = orientation === recommendation?.best;
     const isCustom = paperSize === 'custom';
 
     const fmt = (mm) => formatDimension(mm, unit);
-    const landscapeW = fmt(paper.height);
-    const landscapeH = fmt(paper.width);
-
     const fragment = DOMPurify.sanitize(`
       <div class="smart-sheet-config">
         <div class="smart-sheet-section">

--- a/src/services/FormValidationService.js
+++ b/src/services/FormValidationService.js
@@ -137,23 +137,6 @@ export function initSettingsValidation(container = document) {
   return validator;
 }
 
-/**
- * Create an email validation example (for reference)
- * Demonstrates classic form validation patterns
- */
-export function createEmailValidationExample() {
-  // Example validator for an email input
-  return {
-    rules: [
-      VALIDATION_RULES.required,
-      VALIDATION_RULES.email
-    ],
-    timing: VALIDATION_TIMING.DEBOUNCED,
-    constraints: {
-      format: 'example@domain.com'
-    }
-  };
-}
 
 /**
  * Create a password validation example

--- a/tests/unit/services/form_validation_service.spec.js
+++ b/tests/unit/services/form_validation_service.spec.js
@@ -12,7 +12,6 @@ test.beforeAll(() => {
 
 test.describe('FormValidationService Tests', () => {
   let initSettingsValidation;
-  let createEmailValidationExample;
   let createPasswordValidationExample;
   let createValidationDemo;
   let showValidationErrorWithAction;
@@ -23,7 +22,6 @@ test.describe('FormValidationService Tests', () => {
     // Dynamic import to ensure JSDOM is setup first
     const FormValidationService = await import('../../../src/services/FormValidationService.js');
     initSettingsValidation = FormValidationService.initSettingsValidation;
-    createEmailValidationExample = FormValidationService.createEmailValidationExample;
     createPasswordValidationExample = FormValidationService.createPasswordValidationExample;
     createValidationDemo = FormValidationService.createValidationDemo;
     showValidationErrorWithAction = FormValidationService.showValidationErrorWithAction;
@@ -129,14 +127,6 @@ test.describe('FormValidationService Tests', () => {
       marginConfig.onValidationChange({ isValid: false }, marginInput);
 
       expect(marginInput.value).toBe(MARGIN_MAX.toString());
-    });
-  });
-
-  test.describe('createEmailValidationExample', () => {
-    test('returns correct email validation configuration', () => {
-      const config = createEmailValidationExample();
-      expect(config.rules).toHaveLength(2); // required, email
-      expect(config.constraints.format).toBe('example@domain.com');
     });
   });
 


### PR DESCRIPTION
🎯 **What:**
Removed the `createEmailValidationExample` function from `src/services/FormValidationService.js` and its associated unit tests. Also cleaned up some unused variables (`paper`, `landscapeW`, `landscapeH`) in `src/components/SmartSheetConfig.js` to fix linting errors.

💡 **Why:**
The function `createEmailValidationExample` was commented out or only served as an example. Removing dead or example code improves maintainability, readability, and reduces noise in the codebase.

✅ **Verification:**
Ran the test suite and ensured `tests/unit/services/form_validation_service.spec.js` passes perfectly. Ran `pnpm lint` and ensured there are no linting errors.

✨ **Result:**
A cleaner codebase with less dead code and resolved unused variable warnings.

---
*PR created automatically by Jules for task [10442151826784466553](https://jules.google.com/task/10442151826784466553) started by @guitarbeat*

## Summary by Sourcery

Remove example email validation helper and related tests, and clean up unused SmartSheetConfig variables to reduce dead code and lint warnings.

Bug Fixes:
- Resolve lint warnings by removing unused paper size variables in SmartSheetConfig.

Enhancements:
- Remove the createEmailValidationExample reference implementation from FormValidationService and its unit tests to eliminate dead/example code.