### PR TITLE
🧹 [Code Health] Remove commented out validation example

### DIFF
--- a/src/services/FormValidationService.js
+++ b/src/services/FormValidationService.js
@@ -138,24 +138,6 @@ export function initSettingsValidation(container = document) {
 }
 
 /**
- * Create an email validation example (for reference)
- * Demonstrates classic form validation patterns
- */
-export function createEmailValidationExample() {
-  // Example validator for an email input
-  return {
-    rules: [
-      VALIDATION_RULES.required,
-      VALIDATION_RULES.email
-    ],
-    timing: VALIDATION_TIMING.DEBOUNCED,
-    constraints: {
-      format: 'example@domain.com'
-    }
-  };
-}
-
-/**
  * Create a password validation example
  * Demonstrates multi-rule validation with helpful constraints
  */

--- a/tests/unit/services/form_validation_service.spec.js
+++ b/tests/unit/services/form_validation_service.spec.js
@@ -12,7 +12,6 @@ test.beforeAll(() => {
 
 test.describe('FormValidationService Tests', () => {
   let initSettingsValidation;
-  let createEmailValidationExample;
   let createPasswordValidationExample;
   let createValidationDemo;
   let showValidationErrorWithAction;
@@ -23,7 +22,6 @@ test.describe('FormValidationService Tests', () => {
     // Dynamic import to ensure JSDOM is setup first
     const FormValidationService = await import('../../../src/services/FormValidationService.js');
     initSettingsValidation = FormValidationService.initSettingsValidation;
-    createEmailValidationExample = FormValidationService.createEmailValidationExample;
     createPasswordValidationExample = FormValidationService.createPasswordValidationExample;
     createValidationDemo = FormValidationService.createValidationDemo;
     showValidationErrorWithAction = FormValidationService.showValidationErrorWithAction;
@@ -132,13 +130,6 @@ test.describe('FormValidationService Tests', () => {
     });
   });
 
-  test.describe('createEmailValidationExample', () => {
-    test('returns correct email validation configuration', () => {
-      const config = createEmailValidationExample();
-      expect(config.rules).toHaveLength(2); // required, email
-      expect(config.constraints.format).toBe('example@domain.com');
-    });
-  });
 
   test.describe('createPasswordValidationExample', () => {
     test('returns correct password validation configuration', () => {


### PR DESCRIPTION
🎯 **What:**
Removed the `createEmailValidationExample` function from `src/services/FormValidationService.js` and all of its associated tests in `tests/unit/services/form_validation_service.spec.js`.

💡 **Why:**
This function was specifically documented as an "example (for reference)" and was completely unused by the application. Removing dead code and obsolete examples improves the readability and maintainability of the codebase, reducing confusion for future developers.

✅ **Verification:**
1. Ran `git diff` to verify only the intended function and its tests were removed.
2. Ran `pnpm test tests/unit/services/form_validation_service.spec.js` and confirmed the remaining test suite for the module passes successfully.
3. Ran `pnpm test` and `pnpm lint` across the repository to ensure no regressions or broken imports were introduced (any failing tests or lint errors are pre-existing and unrelated to this change).

✨ **Result:**
A cleaner `FormValidationService` file without unnecessary example code, leading to improved code health.

---
*PR created automatically by Jules for task [9446334043232978401](https://jules.google.com/task/9446334043232978401) started by @guitarbeat*

## Summary by Sourcery

Remove unused email validation example and its tests from FormValidationService.

Enhancements:
- Clean up FormValidationService by removing obsolete createEmailValidationExample helper.

Tests:
- Remove unit tests associated with the deprecated email validation example helper.