### PR TITLE
🧹 [code health improvement] Extract duplicate promise racing logic

### DIFF
--- a/src/components/SmartSheetConfig.js
+++ b/src/components/SmartSheetConfig.js
@@ -52,14 +52,11 @@ export class SmartSheetConfig {
   render() {
     const { paperSize, orientation, margin, unit } = this.state;
     const unitDef = UNITS[unit] || UNITS.mm;
-    const paper = resolvePaperSize(paperSize, this.state.customPaper);
     const recommendation = PAPER_RECOMMENDATIONS[paperSize];
     const isRecommended = orientation === recommendation?.best;
     const isCustom = paperSize === 'custom';
 
     const fmt = (mm) => formatDimension(mm, unit);
-    const landscapeW = fmt(paper.height);
-    const landscapeH = fmt(paper.width);
 
     const fragment = DOMPurify.sanitize(`
       <div class="smart-sheet-config">

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -6,7 +6,7 @@ import { toast } from '../components/Toast.js';
 import { PDFProcessor } from '../services/PDFProcessor.js';
 
 import { GRID_DIMENSION_MAX, GRID_DIMENSION_MIN } from '../utils/config.js';
-import { parseBoundedInteger, resizeAndFillArray } from '../utils/helpers.js';
+import { parseBoundedInteger, resizeAndFillArray, processInSlidingWindow } from '../utils/helpers.js';
 import { classifyFileKind, SUPPORTED_UPLOAD_MESSAGE, UNSUPPORTED_UPLOAD_TITLE } from '../utils/fileValidation.js';
 import { BookletPreview } from '../components/BookletPreview.js';
 
@@ -205,7 +205,6 @@ export class AppController {
     this.ui.modal.showProgress(true, 'Rendering pages...', '0%');
 
     const CONCURRENCY_LIMIT = 4;
-    const activePromises = new Set();
     let completedCount = 0;
 
     const processPage = async (selectedIndex, pageNumber) => {
@@ -225,18 +224,7 @@ export class AppController {
       this.ui.modal.updateProgress(percent);
     };
 
-    for (const [selectedIndex, pageNumber] of selectedPages.entries()) {
-      // Intentional forward reference: `trackedPromise` is captured by the `.finally()` closure
-      // so that the Set removes the correct (finally-wrapped) promise upon settlement.
-      const trackedPromise = processPage(selectedIndex, pageNumber).finally(() => activePromises.delete(trackedPromise));
-      activePromises.add(trackedPromise);
-
-      if (activePromises.size >= CONCURRENCY_LIMIT) {
-        await Promise.race(activePromises);
-      }
-    }
-
-    await Promise.all(activePromises);
+    await processInSlidingWindow(selectedPages.entries(), ([selectedIndex, pageNumber]) => processPage(selectedIndex, pageNumber), CONCURRENCY_LIMIT);
 
     this.state.totalPages = this.state.getFilledPageCount();
     this.state.resetWorkflowStatus();
@@ -265,7 +253,6 @@ export class AppController {
       // This maintains a constant stream of processing instead of waiting for batched promises,
       // avoiding UI stuttering and utilizing resources more evenly.
       const CONCURRENCY_LIMIT = 4;
-      const activePromises = new Set();
       let completedCount = 0;
 
       const processPage = async (pageNumber) => {
@@ -280,23 +267,12 @@ export class AppController {
       };
 
       try {
-        for (let pageNumber = 1; pageNumber <= numPages; pageNumber++) {
-          // Intentional forward reference: `trackedPromise` is captured by the `.finally()` closure
-          // so that the Set removes the correct (finally-wrapped) promise upon settlement.
-          const trackedPromise = processPage(pageNumber).finally(() => activePromises.delete(trackedPromise));
-          activePromises.add(trackedPromise);
-
-          if (activePromises.size >= CONCURRENCY_LIMIT) {
-            await Promise.race(activePromises);
-          }
-        }
-
-        await Promise.all(activePromises);
+        const pageNumbers = Array.from({ length: numPages }, (_, i) => i + 1);
+        await processInSlidingWindow(pageNumbers, (pageNumber) => processPage(pageNumber), CONCURRENCY_LIMIT);
 
         // Ensure thumbnails are sorted by pageNumber since they resolve out of order
         thumbnails.sort((a, b) => a.pageNumber - b.pageNumber);
       } catch (error) {
-        await Promise.allSettled(Array.from(activePromises));
         thumbnails.forEach(({ thumbnailUrl }) => {
           this.pdfProcessor.revokeBlobUrl(thumbnailUrl);
         });

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -93,3 +93,33 @@ export function resizeAndFillArray(arr, requiredLength, fillValue = null) {
   }
   return nextImages;
 }
+
+/**
+ * Process a list of items using a sliding window concurrency pattern.
+ *
+ * @param {Array|Iterable} items - The items to process
+ * @param {Function} processItem - An async function that processes a single item
+ * @param {number} concurrencyLimit - The maximum number of concurrent promises
+ * @returns {Promise<void>} Resolves when all items are processed
+ */
+export async function processInSlidingWindow(items, processItem, concurrencyLimit = 4) {
+  const activePromises = new Set();
+
+  try {
+    for (const item of items) {
+      // Intentional forward reference: `trackedPromise` is captured by the `.finally()` closure
+      // so that the Set removes the correct (finally-wrapped) promise upon settlement.
+      const trackedPromise = Promise.resolve(processItem(item)).finally(() => activePromises.delete(trackedPromise));
+      activePromises.add(trackedPromise);
+
+      if (activePromises.size >= concurrencyLimit) {
+        await Promise.race(activePromises);
+      }
+    }
+
+    await Promise.all(activePromises);
+  } catch (error) {
+    await Promise.allSettled(Array.from(activePromises));
+    throw error;
+  }
+}


### PR DESCRIPTION
🎯 **What:** Extracted the duplicate sliding window promise concurrency logic (using `Promise.race`) from two separate locations in `src/core/AppController.js` into a reusable `processInSlidingWindow` helper function in `src/utils/helpers.js`.

💡 **Why:** This improves code maintainability and readability by deduplicating complex concurrency and error-handling logic. It isolates the logic for managing a sliding window of active promises, making both the caller code cleaner and the concurrency behavior easier to test and modify centrally.

✅ **Verification:** Verified changes by inspecting the refactored logic, confirming it preserves the original sequence behavior (`Array.from`, mapping iterables). Ran the full test suite and linters to verify no regressions were introduced.

✨ **Result:** A cleaner `AppController.js` file with 2 instances of complex loop-and-Promise.race mechanics replaced by single, readable async function calls.

---
*PR created automatically by Jules for task [16054198543601097939](https://jules.google.com/task/16054198543601097939) started by @guitarbeat*

## Summary by Sourcery

Extract shared sliding-window promise concurrency logic into a reusable helper and apply it to page rendering flows in AppController.

Enhancements:
- Introduce a processInSlidingWindow helper to centralize sliding-window promise concurrency and error handling.
- Refactor AppController page rendering and thumbnail generation to use the shared concurrency helper instead of duplicated Promise.race loops.