### PR TITLE
Redesign workspace panels and modernize studio styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,12 @@
                         <section class="brand-panel" aria-label="Zine-ify">
                             <img src="/icons/zine-ify-logo.jpg" alt="Zine-ify logo" width="1536" height="1024" class="logo-image">
                             <div class="app-header-actions">
+                                <button id="exportPdfBtn" type="button"
+                                    class="brand-export-btn"
+                                    disabled aria-label="Export PDF" title="Export your zine as a printable PDF">
+                                    <span class="material-symbols-outlined" aria-hidden="true">print</span>
+                                    <span>Export PDF</span>
+                                </button>
                                 <button id="pwa-install-trigger" type="button" class="panel-icon-btn" aria-label="Install app" title="Install app" hidden>
                                     <span class="material-symbols-outlined icon-compact" aria-hidden="true">install_mobile</span>
                                 </button>
@@ -171,28 +177,6 @@
                     gs-min-w="2" gs-min-h="2" gs-size-to-content="true">
                     <div class="grid-stack-item-content">
                         <div class="snap-card is-hidden" id="card-display">
-                        </div>
-                    </div>
-                </div>
-
-                <!-- ── PANEL: Export PDF ─────────────────────────────── -->
-                <div class="grid-stack-item"
-                    gs-id="export" gs-x="0" gs-y="13" gs-w="4" gs-h="2"
-                    gs-min-w="2" gs-min-h="2" gs-size-to-content="true">
-                    <div class="grid-stack-item-content">
-                        <div class="snap-card snap-card--action" id="card-export">
-                            <div class="snap-card-handle" title="Drag to move">
-                                <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
-                                <span class="snap-card-label">Export</span>
-                            </div>
-                            <div class="snap-card-body snap-card-body--action">
-                                <button id="exportPdfBtn" type="button"
-                                    class="workspace-action-button panel-action-btn flex items-center justify-center gap-2"
-                                    disabled aria-label="Export PDF" title="Export your zine as a printable PDF">
-                                    <span class="material-symbols-outlined" aria-hidden="true">print</span>
-                                    <span class="font-semibold">Export PDF</span>
-                                </button>
-                            </div>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,9 @@
                     gs-min-w="3" gs-min-h="2" gs-size-to-content="true">
                     <div class="grid-stack-item-content">
                         <section class="brand-panel" aria-label="Zine-ify">
+                            <span class="brand-panel-drag-handle" title="Drag to move" aria-hidden="true">
+                                <span class="material-symbols-outlined" aria-hidden="true">drag_indicator</span>
+                            </span>
                             <img src="/icons/zine-ify-logo.jpg" alt="Zine-ify logo" width="1536" height="1024" class="logo-image">
                             <div class="app-header-actions">
                                 <button id="exportPdfBtn" type="button"

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
                                 <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
                                 <span class="snap-card-label">Settings</span>
                             </div>
-                            <div class="snap-card-body">
+                            <div class="snap-card-body panel-scroll-body">
                                 <section id="settings-group">
                                     <div id="smart-sheet-config-container"></div>
                                     <input type="hidden" id="paper-size-select" value="letter">

--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
         window.__zinePwaPromptEvent = e;
       });
     </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <script>
@@ -36,12 +38,13 @@
 </head>
 
 <body class="mobile-zine-app">
+    <a class="skip-link" href="#workspace-main">Skip to workspace</a>
 
     <!-- ── App shell ─────────────────────────────────── -->
     <div class="app-shell">
 
         <!-- ── GridStack workspace ──────────────────────── -->
-        <div class="gs-wrapper">
+        <main class="gs-wrapper" id="workspace-main" tabindex="-1">
             <div class="grid-stack">
 
                 <!-- ── PANEL: Brand controls ──────────────────────────── -->
@@ -50,7 +53,7 @@
                     gs-min-w="3" gs-min-h="2" gs-size-to-content="true">
                     <div class="grid-stack-item-content">
                         <section class="brand-panel" aria-label="Zine-ify">
-                            <img src="/icons/zine-ify-logo.jpg" alt="Zine-ify logo" class="logo-image">
+                            <img src="/icons/zine-ify-logo.jpg" alt="Zine-ify logo" width="1536" height="1024" class="logo-image">
                             <div class="app-header-actions">
                                 <button id="pwa-install-trigger" type="button" class="panel-icon-btn" aria-label="Install app" title="Install app" hidden>
                                     <span class="material-symbols-outlined icon-compact" aria-hidden="true">install_mobile</span>
@@ -291,14 +294,14 @@
                                     <p class="fold-guide-title">8 pages · 1 sheet · 1 cut</p>
                                 </div>
                                 <ol class="fold-guide-list" aria-label="Folding steps">
-                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">1</span><span class="fold-guide-text">Design your zine on one sheet, with the pages in this order and orientation.</span></div><img src="/fold-guide/step-0-plan.png" alt="Page layout diagram" class="fold-guide-img" loading="lazy" /></li>
-                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">2</span><span class="fold-guide-text">Crease the sheet along both main directions — fold in half each way, then open flat.</span></div><img src="/fold-guide/step-1-crease.png" alt="Sheet with crease lines" class="fold-guide-img" loading="lazy" /></li>
-                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">3</span><span class="fold-guide-text">Make two more creases to divide the long direction into quarters, then open flat again.</span></div><img src="/fold-guide/step-2-quarters.png" alt="Quarter crease marks" class="fold-guide-img" loading="lazy" /></li>
-                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">4</span><span class="fold-guide-text">Fold in half, then cut along the center crease — only as far as the quarter-fold marks.</span></div><img src="/fold-guide/step-3-cut.png" alt="Center cut" class="fold-guide-img" loading="lazy" /></li>
-                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">5</span><span class="fold-guide-text">Open it out flat. You'll see a short slit through the center.</span></div><img src="/fold-guide/step-4-open.png" alt="Center slit" class="fold-guide-img" loading="lazy" /></li>
-                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">6</span><span class="fold-guide-text">Fold in half along the long direction so all pages stay on the outside.</span></div><img src="/fold-guide/step-5-fold-strip.png" alt="Long strip fold" class="fold-guide-img" loading="lazy" /></li>
-                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">7</span><span class="fold-guide-text">Push inward from both ends — the slit opens into a cross. Bring pages together with cover outermost.</span></div><img src="/fold-guide/step-6-push-in.png" alt="Diamond cross" class="fold-guide-img" loading="lazy" /></li>
-                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">8</span><span class="fold-guide-text">Fold flat and crease. You now have an 8-page booklet.</span></div><img src="/fold-guide/step-7-done.png" alt="Finished booklet" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">1</span><span class="fold-guide-text">Design your zine on one sheet, with the pages in this order and orientation.</span></div><img src="/fold-guide/step-0-plan.png" alt="Page layout diagram" width="161" height="114" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">2</span><span class="fold-guide-text">Crease the sheet along both main directions — fold in half each way, then open flat.</span></div><img src="/fold-guide/step-1-crease.png" alt="Sheet with crease lines" width="161" height="113" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">3</span><span class="fold-guide-text">Make two more creases to divide the long direction into quarters, then open flat again.</span></div><img src="/fold-guide/step-2-quarters.png" alt="Quarter crease marks" width="145" height="137" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">4</span><span class="fold-guide-text">Fold in half, then cut along the center crease — only as far as the quarter-fold marks.</span></div><img src="/fold-guide/step-3-cut.png" alt="Center cut" width="90" height="113" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">5</span><span class="fold-guide-text">Open it out flat. You'll see a short slit through the center.</span></div><img src="/fold-guide/step-4-open.png" alt="Center slit" width="161" height="129" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">6</span><span class="fold-guide-text">Fold in half along the long direction so all pages stay on the outside.</span></div><img src="/fold-guide/step-5-fold-strip.png" alt="Long strip fold" width="165" height="73" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">7</span><span class="fold-guide-text">Push inward from both ends — the slit opens into a cross. Bring pages together with cover outermost.</span></div><img src="/fold-guide/step-6-push-in.png" alt="Diamond cross" width="122" height="125" class="fold-guide-img" loading="lazy" /></li>
+                                    <li><div class="fold-guide-step-header"><span class="fold-guide-num" aria-hidden="true">8</span><span class="fold-guide-text">Fold flat and crease. You now have an 8-page booklet.</span></div><img src="/fold-guide/step-7-done.png" alt="Finished booklet" width="43" height="68" class="fold-guide-img" loading="lazy" /></li>
                                 </ol>
                             </div>
                         </div>
@@ -306,7 +309,7 @@
                 </div>
 
             </div><!-- /grid-stack -->
-        </div><!-- /gs-wrapper -->
+        </main><!-- /gs-wrapper -->
 
     </div><!-- /app-shell -->
 

--- a/index.html
+++ b/index.html
@@ -173,17 +173,6 @@
                     </div>
                 </div>
 
-                <!-- ── PANEL: Display options ────────────────────────── -->
-                <!-- Merged into Settings panel above -->
-                <div class="grid-stack-item is-hidden"
-                    gs-id="display" gs-x="9" gs-y="11" gs-w="3" gs-h="2"
-                    gs-min-w="2" gs-min-h="2" gs-size-to-content="true">
-                    <div class="grid-stack-item-content">
-                        <div class="snap-card is-hidden" id="card-display">
-                        </div>
-                    </div>
-                </div>
-
                 <!-- ── PANEL: 3D Fold Viewer ────────────────────────────── -->
                 <div class="grid-stack-item"
                     gs-id="fold-viewer" gs-x="0" gs-y="15" gs-w="6" gs-h="6"

--- a/index.html
+++ b/index.html
@@ -53,10 +53,10 @@
                             <img src="/icons/zine-ify-logo.jpg" alt="Zine-ify logo" class="logo-image">
                             <div class="app-header-actions">
                                 <button id="pwa-install-trigger" type="button" class="panel-icon-btn" aria-label="Install app" title="Install app" hidden>
-                                    <span class="material-symbols-outlined" style="font-size:15px;" aria-hidden="true">install_mobile</span>
+                                    <span class="material-symbols-outlined icon-compact" aria-hidden="true">install_mobile</span>
                                 </button>
                                 <button id="theme-toggle" class="panel-icon-btn" aria-label="Toggle dark mode" title="Toggle dark mode">
-                                    <span class="material-symbols-outlined" style="font-size:15px;" id="theme-icon">dark_mode</span>
+                                    <span class="material-symbols-outlined icon-compact" id="theme-icon">dark_mode</span>
                                 </button>
                             </div>
                         </section>
@@ -72,8 +72,8 @@
                             <div class="snap-card-handle" title="Drag to move">
                                 <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
                                 <span class="snap-card-label">Zine layout</span>
-                                <button id="clear-all-btn" type="button" class="panel-clear-btn ml-1" style="display:none;" aria-label="Clear all pages" title="Clear all pages and start over">
-                                    <span class="material-symbols-outlined" style="font-size:13px;" aria-hidden="true">delete_sweep</span>
+                                <button id="clear-all-btn" type="button" class="panel-clear-btn ml-1 is-hidden" aria-label="Clear all pages" title="Clear all pages and start over">
+                                    <span class="material-symbols-outlined icon-tiny" aria-hidden="true">delete_sweep</span>
                                     <span>Start over</span>
                                 </button>
                             </div>
@@ -107,9 +107,9 @@
                                 <div id="upload-zone" class="upload-box flex flex-col items-center justify-center gap-1.5 text-center p-4 cursor-pointer"
                                     role="button" tabindex="0"
                                     aria-label="Add pages — click to browse, or drop PDF and image files here">
-                                    <span class="material-symbols-outlined" style="font-size:22px; color: var(--primary-vibrant);" aria-hidden="true">upload_file</span>
+                                    <span class="material-symbols-outlined upload-icon" aria-hidden="true">upload_file</span>
                                     <span class="text-sm font-semibold">Drop files or click to browse</span>
-                                    <span class="text-xs" style="color:var(--muted-ink)">PDF, PNG, JPG, or WEBP • Max 50 MB each</span>
+                                    <span class="text-xs muted-copy">PDF, PNG, JPG, or WEBP • Max 50 MB each</span>
                                 </div>
                                 <input type="file" id="pdf-upload" class="sr-only"
                                     accept="application/pdf,image/png,image/jpeg,image/webp"
@@ -163,12 +163,11 @@
 
                 <!-- ── PANEL: Display options ────────────────────────── -->
                 <!-- Merged into Settings panel above -->
-                <div class="grid-stack-item"
+                <div class="grid-stack-item is-hidden"
                     gs-id="display" gs-x="9" gs-y="11" gs-w="3" gs-h="2"
-                    gs-min-w="2" gs-min-h="2" gs-size-to-content="true"
-                    style="display: none;">
+                    gs-min-w="2" gs-min-h="2" gs-size-to-content="true">
                     <div class="grid-stack-item-content">
-                        <div class="snap-card" id="card-display" style="display: none;">
+                        <div class="snap-card is-hidden" id="card-display">
                         </div>
                     </div>
                 </div>
@@ -224,10 +223,10 @@
                                     </div>
                                     <div class="fold-viewer-slider-row">
                                         <label for="fold-slider" class="font-semibold text-xs uppercase whitespace-nowrap flex items-center gap-1.5 text-zinc-500">
-                                            <span class="material-symbols-outlined text-[16px]" style="color: var(--primary-vibrant);" aria-hidden="true">animation</span>
+                                            <span class="material-symbols-outlined slider-icon" aria-hidden="true">animation</span>
                                             Position
                                         </label>
-                                        <input type="range" id="fold-slider" min="0" max="3" step="0.01" value="0" class="flex-1 w-full h-1.5 cursor-pointer" style="accent-color: var(--primary-vibrant);">
+                                        <input type="range" id="fold-slider" min="0" max="3" step="0.01" value="0" class="flex-1 w-full h-1.5 cursor-pointer fold-slider">
                                     </div>
                                     <p id="fold-helper" class="fold-viewer-helper">Export the layout, crease the sheet in half both ways and open flat, then fold and make one short cut through the center before collapsing into a booklet.</p>
                                     <div class="fold-viewer-step-grid" aria-label="Fold simulation checkpoints">
@@ -326,7 +325,7 @@
         class="fixed inset-0 z-[100] flex flex-col items-center justify-center p-6 hidden bg-black/30 backdrop-blur-sm"
         role="dialog" aria-modal="true" aria-label="Processing">
         <div class="base-panel w-full max-w-sm text-center">
-            <span class="material-symbols-outlined text-3xl mb-3 block" style="color: var(--primary-vibrant);" aria-hidden="true">sync</span>
+            <span class="material-symbols-outlined progress-icon text-3xl mb-3 block" aria-hidden="true">sync</span>
             <h3 id="progress-text" class="text-lg font-semibold mb-4" aria-live="polite" aria-atomic="true">Processing…</h3>
             <div class="progress-bar-container mb-3" id="progress-bar-wrap" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
                 <div id="progress-fill"></div>

--- a/index.html
+++ b/index.html
@@ -134,8 +134,8 @@
                 </div>
 
                 <!-- ── PANEL: Page settings ──────────────────────────── -->
-                <div class="grid-stack-item attachable-panel-item"
-                    gs-id="settings" gs-x="9" gs-y="7" gs-w="3" gs-h="10"
+                <div class="grid-stack-item attachable-panel-item settings-panel-item"
+                    gs-id="settings" gs-x="9" gs-y="7" gs-w="3" gs-h="8"
                     gs-min-w="2" gs-min-h="8" gs-size-to-content="true">
                     <div class="grid-stack-item-content">
                         <div class="snap-card" id="card-settings">

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                 </div>
 
                 <!-- ── PANEL: Canvas preview ──────────────────────────── -->
-                <div class="grid-stack-item"
+                <div class="grid-stack-item attachable-panel-item"
                     gs-id="canvas" gs-x="0" gs-y="3" gs-w="9" gs-h="10"
                     gs-min-w="4" gs-min-h="3" gs-size-to-content="true">
                     <div class="grid-stack-item-content">
@@ -100,39 +100,6 @@
                                         <div id="command-deck" class="command-deck-container hidden"></div>
                                     </div>
                                 </div>
-                                <section class="canvas-settings-dock panel-scroll-body" id="card-settings" aria-labelledby="canvas-settings-title">
-                                    <div class="canvas-settings-heading">
-                                        <div>
-                                            <p class="canvas-settings-kicker">Sheet setup</p>
-                                            <h2 id="canvas-settings-title" class="canvas-settings-title">Prepare your zine</h2>
-                                        </div>
-                                        <span class="material-symbols-outlined canvas-settings-icon" aria-hidden="true">tune</span>
-                                    </div>
-                                    <section id="settings-group">
-                                        <div id="smart-sheet-config-container"></div>
-                                        <input type="hidden" id="paper-size-select" value="letter">
-                                        <input type="hidden" id="orientation-toggle" value="landscape">
-                                    </section>
-                                    <hr class="workspace-config-divider">
-                                    <section id="display-group">
-                                        <p class="workspace-config-group-label">Display</p>
-                                        <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-numbers">
-                                            <span class="workspace-config-toggle-copy">Page Numbers</span>
-                                            <input type="checkbox" id="show-page-numbers" checked class="workspace-config-toggle-input">
-                                            <span class="workspace-config-toggle-switch" aria-hidden="true">
-                                                <span class="workspace-config-toggle-knob"></span>
-                                            </span>
-                                        </label>
-                                        <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-controls">
-                                            <span class="workspace-config-toggle-copy">Page Controls</span>
-                                            <input type="checkbox" id="show-page-controls" checked class="workspace-config-toggle-input">
-                                            <span class="workspace-config-toggle-switch" aria-hidden="true">
-                                                <span class="workspace-config-toggle-knob"></span>
-                                            </span>
-                                        </label>
-                                        <p class="workspace-config-hint">Preview only — won't print.</p>
-                                    </section>
-                                </section>
                             </div>
                         </div>
                     </div>
@@ -161,6 +128,47 @@
                                     multiple aria-hidden="true" tabindex="-1" />
                                 <p id="upload-status" class="upload-status" aria-live="polite"></p>
                                 <section id="uploaded-files-list" class="hidden"></section>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ── PANEL: Page settings ──────────────────────────── -->
+                <div class="grid-stack-item attachable-panel-item"
+                    gs-id="settings" gs-x="9" gs-y="7" gs-w="3" gs-h="10"
+                    gs-min-w="2" gs-min-h="8" gs-size-to-content="true">
+                    <div class="grid-stack-item-content">
+                        <div class="snap-card" id="card-settings">
+                            <div class="snap-card-handle" title="Drag to move">
+                                <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
+                                <span class="snap-card-label">Sheet setup</span>
+                                <span class="panel-attach-hint" aria-hidden="true">Dockable</span>
+                            </div>
+                            <div class="snap-card-body panel-scroll-body">
+                                <section id="settings-group">
+                                    <div id="smart-sheet-config-container"></div>
+                                    <input type="hidden" id="paper-size-select" value="letter">
+                                    <input type="hidden" id="orientation-toggle" value="landscape">
+                                </section>
+                                <hr class="workspace-config-divider">
+                                <section id="display-group">
+                                    <p class="workspace-config-group-label">Display</p>
+                                    <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-numbers">
+                                        <span class="workspace-config-toggle-copy">Page Numbers</span>
+                                        <input type="checkbox" id="show-page-numbers" checked class="workspace-config-toggle-input">
+                                        <span class="workspace-config-toggle-switch" aria-hidden="true">
+                                            <span class="workspace-config-toggle-knob"></span>
+                                        </span>
+                                    </label>
+                                    <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-controls">
+                                        <span class="workspace-config-toggle-copy">Page Controls</span>
+                                        <input type="checkbox" id="show-page-controls" checked class="workspace-config-toggle-input">
+                                        <span class="workspace-config-toggle-switch" aria-hidden="true">
+                                            <span class="workspace-config-toggle-knob"></span>
+                                        </span>
+                                    </label>
+                                    <p class="workspace-config-hint">Preview only — won't print.</p>
+                                </section>
                             </div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -134,9 +134,9 @@
                 </div>
 
                 <!-- ── PANEL: Page settings ──────────────────────────── -->
-                <div class="grid-stack-item settings-panel-item"
-                    gs-id="settings" gs-x="9" gs-y="7" gs-w="3" gs-h="6"
-                    gs-min-w="2" gs-min-h="2" gs-size-to-content="true">
+                <div class="grid-stack-item"
+                    gs-id="settings" gs-x="9" gs-y="7" gs-w="3" gs-h="10"
+                    gs-min-w="2" gs-min-h="8" gs-size-to-content="true">
                     <div class="grid-stack-item-content">
                         <div class="snap-card" id="card-settings">
                             <div class="snap-card-handle" title="Drag to move">

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
                 </div>
 
                 <!-- ── PANEL: Page settings ──────────────────────────── -->
-                <div class="grid-stack-item"
+                <div class="grid-stack-item settings-panel-item"
                     gs-id="settings" gs-x="9" gs-y="7" gs-w="3" gs-h="6"
                     gs-min-w="2" gs-min-h="2" gs-size-to-content="true">
                     <div class="grid-stack-item-content">

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
                                 <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
                                 <span class="snap-card-label">Add pages</span>
                             </div>
-                            <div class="snap-card-body">
+                            <div class="snap-card-body panel-scroll-body">
                                 <div id="upload-zone" class="upload-box flex flex-col items-center justify-center gap-1.5 text-center p-4 cursor-pointer"
                                     role="button" tabindex="0"
                                     aria-label="Add pages — click to browse, or drop PDF and image files here">
@@ -275,7 +275,7 @@
                                 <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
                                 <span class="snap-card-label">How to Fold</span>
                             </div>
-                            <div class="snap-card-body snap-card-body--fold-guide">
+                            <div class="snap-card-body snap-card-body--fold-guide panel-scroll-body">
                                 <div class="fold-guide-header">
                                     <p class="fold-guide-kicker">How to fold</p>
                                     <p class="fold-guide-title">8 pages · 1 sheet · 1 cut</p>

--- a/index.html
+++ b/index.html
@@ -100,6 +100,39 @@
                                         <div id="command-deck" class="command-deck-container hidden"></div>
                                     </div>
                                 </div>
+                                <section class="canvas-settings-dock panel-scroll-body" id="card-settings" aria-labelledby="canvas-settings-title">
+                                    <div class="canvas-settings-heading">
+                                        <div>
+                                            <p class="canvas-settings-kicker">Sheet setup</p>
+                                            <h2 id="canvas-settings-title" class="canvas-settings-title">Prepare your zine</h2>
+                                        </div>
+                                        <span class="material-symbols-outlined canvas-settings-icon" aria-hidden="true">tune</span>
+                                    </div>
+                                    <section id="settings-group">
+                                        <div id="smart-sheet-config-container"></div>
+                                        <input type="hidden" id="paper-size-select" value="letter">
+                                        <input type="hidden" id="orientation-toggle" value="landscape">
+                                    </section>
+                                    <hr class="workspace-config-divider">
+                                    <section id="display-group">
+                                        <p class="workspace-config-group-label">Display</p>
+                                        <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-numbers">
+                                            <span class="workspace-config-toggle-copy">Page Numbers</span>
+                                            <input type="checkbox" id="show-page-numbers" checked class="workspace-config-toggle-input">
+                                            <span class="workspace-config-toggle-switch" aria-hidden="true">
+                                                <span class="workspace-config-toggle-knob"></span>
+                                            </span>
+                                        </label>
+                                        <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-controls">
+                                            <span class="workspace-config-toggle-copy">Page Controls</span>
+                                            <input type="checkbox" id="show-page-controls" checked class="workspace-config-toggle-input">
+                                            <span class="workspace-config-toggle-switch" aria-hidden="true">
+                                                <span class="workspace-config-toggle-knob"></span>
+                                            </span>
+                                        </label>
+                                        <p class="workspace-config-hint">Preview only — won't print.</p>
+                                    </section>
+                                </section>
                             </div>
                         </div>
                     </div>
@@ -128,46 +161,6 @@
                                     multiple aria-hidden="true" tabindex="-1" />
                                 <p id="upload-status" class="upload-status" aria-live="polite"></p>
                                 <section id="uploaded-files-list" class="hidden"></section>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- ── PANEL: Page settings ──────────────────────────── -->
-                <div class="grid-stack-item"
-                    gs-id="settings" gs-x="9" gs-y="7" gs-w="3" gs-h="10"
-                    gs-min-w="2" gs-min-h="8" gs-size-to-content="true">
-                    <div class="grid-stack-item-content">
-                        <div class="snap-card" id="card-settings">
-                            <div class="snap-card-handle" title="Drag to move">
-                                <span class="material-symbols-outlined snap-card-grip" aria-hidden="true">drag_indicator</span>
-                                <span class="snap-card-label">Settings</span>
-                            </div>
-                            <div class="snap-card-body panel-scroll-body">
-                                <section id="settings-group">
-                                    <div id="smart-sheet-config-container"></div>
-                                    <input type="hidden" id="paper-size-select" value="letter">
-                                    <input type="hidden" id="orientation-toggle" value="landscape">
-                                </section>
-                                <hr class="workspace-config-divider">
-                                <section id="display-group">
-                                    <p class="workspace-config-group-label">Display</p>
-                                    <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-numbers">
-                                        <span class="workspace-config-toggle-copy">Page Numbers</span>
-                                        <input type="checkbox" id="show-page-numbers" checked class="workspace-config-toggle-input">
-                                        <span class="workspace-config-toggle-switch" aria-hidden="true">
-                                            <span class="workspace-config-toggle-knob"></span>
-                                        </span>
-                                    </label>
-                                    <label class="workspace-config-toggle workspace-config-field workspace-config-field-wide" for="show-page-controls">
-                                        <span class="workspace-config-toggle-copy">Page Controls</span>
-                                        <input type="checkbox" id="show-page-controls" checked class="workspace-config-toggle-input">
-                                        <span class="workspace-config-toggle-switch" aria-hidden="true">
-                                            <span class="workspace-config-toggle-knob"></span>
-                                        </span>
-                                    </label>
-                                    <p class="workspace-config-hint">Preview only — won't print.</p>
-                                </section>
                             </div>
                         </div>
                     </div>

--- a/src/components/SmartSheetConfig.js
+++ b/src/components/SmartSheetConfig.js
@@ -52,14 +52,11 @@ export class SmartSheetConfig {
   render() {
     const { paperSize, orientation, margin, unit } = this.state;
     const unitDef = UNITS[unit] || UNITS.mm;
-    const paper = resolvePaperSize(paperSize, this.state.customPaper);
     const recommendation = PAPER_RECOMMENDATIONS[paperSize];
     const isRecommended = orientation === recommendation?.best;
     const isCustom = paperSize === 'custom';
 
     const fmt = (mm) => formatDimension(mm, unit);
-    const landscapeW = fmt(paper.height);
-    const landscapeH = fmt(paper.width);
 
     const fragment = DOMPurify.sanitize(`
       <div class="smart-sheet-config">

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -5,7 +5,7 @@
   border-radius: var(--radius-panel);
   background-color: var(--surface-muted);
   min-height: 9rem;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
   box-shadow: inset 0 0 0 1px var(--border-faint);
   position: relative;
 }
@@ -79,7 +79,7 @@
   cursor: pointer;
   color: var(--muted-ink);
   margin-left: auto;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
   flex-shrink: 0;
 }
 .uploaded-file-remove:hover {
@@ -450,7 +450,7 @@ select:focus, input:focus {
   border: 1px solid var(--border-color) !important;
   border-radius: var(--radius-button) !important;
   box-shadow: var(--shadow-sm);
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
   font-weight: 700;
   letter-spacing: 0.02em;
   font-size: 0.82rem;
@@ -535,7 +535,7 @@ select:focus, input:focus {
   letter-spacing: 0.04em;
   padding: 0.45rem 0.8rem;
   text-transform: uppercase;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }
 
 .page-picker-chip:hover,
@@ -565,7 +565,7 @@ select:focus, input:focus {
   overflow: hidden;
   padding: 0.65rem;
   text-align: left;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }
 
 .page-picker-thumb:hover,
@@ -738,7 +738,7 @@ select:focus, input:focus {
 
 /* Action buttons lift */
 .action-button {
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }
 .action-button:hover:not(:disabled) {
   transform: translateY(-2px);
@@ -1037,7 +1037,7 @@ select.is-valid:focus {
   padding: 0.2rem 0.5rem;
   background: var(--primary-glow);
   border-radius: var(--radius-pill);
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }
 
 .smart-sheet-status.is-warning {
@@ -1063,7 +1063,7 @@ select.is-valid:focus {
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
 }
 
 .smart-sheet-preset:hover {
@@ -1101,7 +1101,7 @@ select.is-valid:focus {
   background: var(--muted-ink);
   border-radius: 1px;
   opacity: 0.5;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }
 
 .smart-sheet-preset:hover .smart-sheet-preset-cell,
@@ -1157,7 +1157,7 @@ select.is-valid:focus {
   border: 1px solid var(--border-faint);
   border-radius: 3px;
   cursor: pointer;
-  transition: all 0.12s ease;
+  transition: background-color 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease, color 0.12s ease, opacity 0.12s ease, transform 0.12s ease;
   padding: 0;
 }
 
@@ -1209,7 +1209,7 @@ select.is-valid:focus {
   font-size: 0.85rem;
   color: var(--muted-ink);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }
 
 .smart-sheet-stepper-btn:hover {
@@ -1266,7 +1266,7 @@ select.is-valid:focus {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='7' viewBox='0 0 11 7'%3E%3Cpath d='M1 1l4.5 4.5L10 1' stroke='%2371717a' stroke-width='1.6' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 0.7rem center;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }
 
 .smart-sheet-select:hover {
@@ -1324,7 +1324,7 @@ select.is-valid:focus {
   border: 1px solid var(--border-color);
   border-radius: 0.5rem;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }
 
 .smart-sheet-orientation-btn:hover {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -163,6 +163,12 @@ body {
   box-shadow: 3px 3px 0 var(--workspace-edge), var(--shadow-sm);
 }
 
+.settings-panel-item,
+.settings-panel-item > .grid-stack-item-content,
+.settings-panel-item #card-settings {
+  overflow: visible;
+}
+
 .snap-card:hover {
   transform: translate(-1px, -1px);
   box-shadow: 4px 4px 0 var(--primary-vibrant), var(--shadow-md);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -168,6 +168,15 @@ body {
   box-shadow: 4px 4px 0 var(--primary-vibrant), var(--shadow-md);
 }
 
+.panel-scroll-body {
+  min-height: 0;
+  max-height: min(70vh, 34rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--primary-vibrant) var(--surface-muted);
+}
+
 .snap-card--canvas {
   background: var(--surface-paper-stack);
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -34,6 +34,31 @@ body {
   font-family: 'Inter', sans-serif;
 }
 
+.skip-link {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 100;
+  padding: 0.55rem 0.8rem;
+  color: var(--surface-bg);
+  background: var(--accent-dark);
+  border: 2px solid var(--primary-vibrant);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  transform: translateY(-150%);
+  transition: transform 0.15s ease;
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+}
+
+#workspace-main:focus {
+  outline: none;
+}
+
 .app-shell {
   position: relative;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -79,14 +79,22 @@ body {
 .brand-panel {
   position: relative;
   z-index: 25;
+  width: min(100%, 34rem);
+  box-sizing: border-box;
   margin-top: 0.85rem;
+  justify-content: space-between;
+  overflow: hidden;
   border-color: var(--workspace-edge);
   box-shadow: 5px 5px 0 var(--primary-vibrant), var(--shadow-md);
 }
 
 .brand-panel .logo-image {
-  height: 5rem;
+  flex: 1 1 auto;
+  min-width: 0;
   width: auto;
+  max-width: 14rem;
+  height: 5rem;
+  object-fit: contain;
 }
 
 .brand-export-btn {
@@ -106,6 +114,8 @@ body {
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
+  white-space: nowrap;
+  flex-shrink: 0;
   cursor: pointer;
   transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -97,6 +97,30 @@ body {
   object-fit: contain;
 }
 
+.brand-panel-drag-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 1.1rem;
+  color: rgba(255, 255, 255, 0.42);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.brand-panel-drag-handle:active {
+  cursor: grabbing;
+}
+
+.brand-panel-drag-handle .material-symbols-outlined {
+  font-size: 1rem;
+}
+
+.brand-panel:hover .brand-panel-drag-handle {
+  color: var(--primary-vibrant);
+}
+
 .brand-export-btn {
   display: inline-flex;
   align-items: center;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -85,7 +85,42 @@ body {
 }
 
 .brand-panel .logo-image {
-  height: 3.6rem;
+  height: 5rem;
+  width: auto;
+}
+
+.brand-export-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.7rem;
+  color: #fff;
+  background: var(--primary-vibrant);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: var(--radius-button);
+  box-shadow: 2px 2px 0 rgba(255, 255, 255, 0.18);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
+}
+
+.brand-export-btn:not(:disabled):hover {
+  background: var(--primary-deep);
+  border-color: #fff;
+  box-shadow: 3px 3px 0 rgba(255, 255, 255, 0.24);
+  transform: translate(-1px, -1px);
+}
+
+.brand-export-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .snap-card {
@@ -180,7 +215,12 @@ body {
   }
 
   .brand-panel .logo-image {
-    height: 2.8rem;
+    height: 3.6rem;
+  }
+
+  .brand-export-btn {
+    padding-inline: 0.5rem;
+    font-size: 0.6rem;
   }
 
   .snap-card:hover {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -370,6 +370,49 @@ body {
   }
 }
 
+.canvas-settings-dock {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  background: var(--surface-muted);
+}
+
+.canvas-settings-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.canvas-settings-kicker {
+  margin: 0 0 0.2rem;
+  color: var(--primary-vibrant);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.canvas-settings-title {
+  margin: 0;
+  color: var(--accent-dark);
+  font-family: 'Fraunces', serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.canvas-settings-icon {
+  color: var(--primary-vibrant);
+  font-size: 1.4rem;
+}
+
 .print-sheet {
   padding: 0.45rem;
   border-radius: 0.75rem;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -9,3 +9,168 @@
 /* Tailwind v4 scanning sources must come after all @imports to satisfy CSS rules */
 @source "../../index.html";
 @source "../**/*.{js,ts,jsx,tsx}";
+
+/* Studio pass: make the workspace feel like a working print table, not a generic dashboard. */
+:root {
+  --workspace-grid: rgba(15, 15, 15, 0.055);
+  --workspace-edge: rgba(15, 15, 15, 0.16);
+}
+
+[data-theme="dark"] {
+  --workspace-grid: rgba(255, 255, 255, 0.045);
+  --workspace-edge: rgba(255, 255, 255, 0.16);
+}
+
+html,
+body {
+  background-color: var(--bg-neutral);
+  background-image:
+    linear-gradient(var(--workspace-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--workspace-grid) 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+}
+
+.app-shell {
+  position: relative;
+}
+
+.app-shell::before {
+  content: "WORK TABLE / SINGLE SHEET SYSTEM";
+  position: fixed;
+  top: 0.7rem;
+  left: 1rem;
+  z-index: 30;
+  color: rgba(255, 255, 255, 0.52);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.55rem;
+  letter-spacing: 0.14em;
+  pointer-events: none;
+}
+
+.brand-panel {
+  position: relative;
+  z-index: 25;
+  margin-top: 0.85rem;
+  border-color: var(--workspace-edge);
+  box-shadow: 5px 5px 0 var(--primary-vibrant), var(--shadow-md);
+}
+
+.brand-panel .logo-image {
+  height: 3.6rem;
+}
+
+.snap-card {
+  border-color: var(--workspace-edge);
+  border-radius: 0.2rem;
+  box-shadow: 3px 3px 0 var(--workspace-edge), var(--shadow-sm);
+}
+
+.snap-card:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 var(--primary-vibrant), var(--shadow-md);
+}
+
+.snap-card--canvas {
+  background: var(--surface-paper-stack);
+}
+
+.snap-card--action {
+  box-shadow: 4px 4px 0 var(--primary-vibrant), var(--shadow-md);
+}
+
+.snap-card--action .panel-action-btn {
+  min-height: 3rem;
+  font-family: 'IBM Plex Mono', monospace;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.upload-box {
+  min-height: 10.5rem;
+  border-radius: 0.2rem;
+}
+
+.upload-icon,
+.slider-icon,
+.progress-icon {
+  color: var(--primary-vibrant);
+}
+
+.upload-icon {
+  font-size: 2rem;
+  transition: transform 0.2s ease;
+}
+
+.upload-box:hover .upload-icon,
+.upload-box:focus .upload-icon {
+  transform: translateY(-3px) rotate(-4deg);
+}
+
+.muted-copy {
+  color: var(--muted-ink);
+}
+
+.icon-compact {
+  font-size: 15px;
+}
+
+.icon-tiny {
+  font-size: 13px;
+}
+
+.fold-slider {
+  accent-color: var(--primary-vibrant);
+}
+
+.progress-icon {
+  animation: progress-pulse 1.25s ease-in-out infinite;
+}
+
+.is-hidden {
+  display: none;
+}
+
+@keyframes progress-pulse {
+  0%, 100% { opacity: 0.45; transform: rotate(0deg); }
+  50% { opacity: 1; transform: rotate(180deg); }
+}
+
+:focus-visible {
+  outline: 2px solid var(--primary-vibrant);
+  outline-offset: 3px;
+}
+
+@media (max-width: 767px) {
+  .app-shell::before {
+    display: none;
+  }
+
+  .brand-panel {
+    margin-top: 0.6rem;
+    box-shadow: 3px 3px 0 var(--primary-vibrant), var(--shadow-sm);
+  }
+
+  .brand-panel .logo-image {
+    height: 2.8rem;
+  }
+
+  .snap-card:hover {
+    transform: none;
+    box-shadow: var(--shadow-sm);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -369,3 +369,57 @@ body {
     box-shadow: var(--shadow-sm);
   }
 }
+
+.print-sheet {
+  padding: 0.45rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
+}
+
+.page-cell {
+  border-color: rgba(15, 15, 15, 0.12);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--surface-muted) 94%, var(--surface-bg));
+}
+
+.page-cell.has-page {
+  background: var(--surface-bg);
+}
+
+.page-cell.has-page:hover {
+  box-shadow: 0 8px 18px var(--primary-glow);
+}
+
+.page-toolbar {
+  gap: 0.35rem;
+  padding: 0.35rem;
+  border-radius: 0.5rem;
+  background: rgba(15, 15, 15, 0.78);
+  backdrop-filter: blur(8px);
+}
+
+.page-tool-btn {
+  border-radius: 0.35rem;
+  box-shadow: none;
+  background: var(--primary-vibrant);
+}
+
+.page-tool-btn:hover {
+  box-shadow: 0 4px 10px var(--primary-glow);
+}
+
+.page-label {
+  bottom: 0.5rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.25rem 0.5rem;
+  box-shadow: none;
+  background: rgba(15, 15, 15, 0.84);
+  backdrop-filter: blur(6px);
+}
+
+.page-placeholder {
+  border: 1px dashed var(--border-color);
+  border-radius: 0.5rem;
+  background: transparent;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -374,6 +374,32 @@ body {
   transition: box-shadow 0.2s ease, outline-color 0.2s ease;
 }
 
+.settings-panel-item .snap-card-handle {
+  min-height: 2rem;
+  padding-block: 0.35rem;
+}
+
+.settings-panel-item .snap-card-body {
+  gap: 0.45rem;
+  padding: 0.75rem;
+}
+
+.settings-panel-item .workspace-config-divider {
+  margin-block: 0.25rem;
+}
+
+.settings-panel-item .workspace-config-group-label {
+  padding-bottom: 0.15rem;
+}
+
+.settings-panel-item .workspace-config-toggle {
+  min-height: 2rem;
+}
+
+.settings-panel-item .workspace-config-hint {
+  margin-top: 0;
+}
+
 .attachable-panel-item:hover > .grid-stack-item-content,
 .attachable-panel-item:focus-within > .grid-stack-item-content {
   outline: 1px solid var(--primary-vibrant);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -163,12 +163,6 @@ body {
   box-shadow: 3px 3px 0 var(--workspace-edge), var(--shadow-sm);
 }
 
-.settings-panel-item,
-.settings-panel-item > .grid-stack-item-content,
-.settings-panel-item #card-settings {
-  overflow: visible;
-}
-
 .snap-card:hover {
   transform: translate(-1px, -1px);
   box-shadow: 4px 4px 0 var(--primary-vibrant), var(--shadow-md);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -370,47 +370,23 @@ body {
   }
 }
 
-.canvas-settings-dock {
-  display: grid;
-  gap: 0.8rem;
-  margin-top: 1rem;
-  padding: 1rem;
-  border: 1px solid var(--border-color);
-  border-radius: 0.75rem;
-  background: var(--surface-muted);
+.attachable-panel-item > .grid-stack-item-content {
+  transition: box-shadow 0.2s ease, outline-color 0.2s ease;
 }
 
-.canvas-settings-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding-bottom: 0.75rem;
-  border-bottom: 1px solid var(--border-color);
+.attachable-panel-item:hover > .grid-stack-item-content,
+.attachable-panel-item:focus-within > .grid-stack-item-content {
+  outline: 1px solid var(--primary-vibrant);
+  outline-offset: 3px;
 }
 
-.canvas-settings-kicker {
-  margin: 0 0 0.2rem;
-  color: var(--primary-vibrant);
+.panel-attach-hint {
+  margin-left: auto;
+  color: rgba(255, 255, 255, 0.45);
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.6rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
+  font-size: 0.52rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-}
-
-.canvas-settings-title {
-  margin: 0;
-  color: var(--accent-dark);
-  font-family: 'Fraunces', serif;
-  font-size: 1.15rem;
-  font-weight: 600;
-  line-height: 1.1;
-}
-
-.canvas-settings-icon {
-  color: var(--primary-vibrant);
-  font-size: 1.4rem;
 }
 
 .print-sheet {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -282,3 +282,90 @@ body {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Modern studio pass: quieter elevation, clearer grouping, same print identity. */
+.gs-wrapper {
+  width: min(100%, 96rem);
+  margin-inline: auto;
+  padding: 1.25rem;
+}
+
+.brand-panel {
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18), 4px 4px 0 var(--primary-vibrant);
+}
+
+.brand-panel .logo-image {
+  border-radius: 0.4rem;
+}
+
+.snap-card {
+  border-radius: 0.75rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+.snap-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.13);
+}
+
+.snap-card-handle {
+  min-height: 2.25rem;
+  padding-inline: 0.9rem;
+  background: linear-gradient(180deg, #171717 0%, #0b0b0b 100%);
+  border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+
+.snap-card-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+}
+
+.upload-box {
+  min-height: 8.5rem;
+  border-width: 1px;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--surface-muted) 92%, var(--primary-glow));
+  box-shadow: none;
+}
+
+.upload-box:hover,
+.upload-box:focus {
+  box-shadow: 0 0 0 3px var(--primary-glow);
+}
+
+.panel-action-btn,
+.brand-export-btn {
+  border-radius: 0.5rem;
+  box-shadow: none;
+}
+
+.panel-action-btn:not(:disabled):hover,
+.brand-export-btn:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px var(--primary-glow);
+}
+
+.workspace-config-input,
+.smart-sheet-select,
+.smart-sheet-custom-input {
+  border-radius: 0.5rem;
+}
+
+@media (max-width: 767px) {
+  .gs-wrapper {
+    padding: 0.75rem;
+  }
+
+  .brand-panel {
+    border-radius: 0.65rem;
+  }
+
+  .snap-card:hover {
+    transform: none;
+    box-shadow: var(--shadow-sm);
+  }
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -146,7 +146,19 @@ body::-webkit-scrollbar {
 }
 
 .grid-stack-item {
-  overflow: hidden;
+  overflow: visible;
+  isolation: isolate;
+  transition: z-index 0s linear;
+}
+
+.grid-stack-item:hover,
+.grid-stack-item:focus-within {
+  z-index: 20 !important;
+}
+
+.grid-stack-item.ui-draggable-dragging,
+.grid-stack-item.ui-resizable-resizing {
+  z-index: 50 !important;
 }
 
 /* Panels fill their gridstack cell */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -415,7 +415,7 @@ body::-webkit-scrollbar {
   background: var(--surface-bg);
   color: var(--accent-dark);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
   flex-shrink: 0;
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -238,7 +238,7 @@ body::-webkit-scrollbar {
 
 /* ─── Panel handle ───────────────────────────────────────── */
 .snap-card-handle {
-  display: none;
+  display: flex;
   cursor: move;
   align-items: center;
   gap: 0.3rem;
@@ -528,7 +528,10 @@ body::-webkit-scrollbar {
 
 /* ─── Responsive: tablet (< 1024px) ─────────────────────── */
 @media (max-width: 1023px) {
-  .ui-resizable-se { display: none !important; }
+  .ui-resizable-se {
+    display: block !important;
+    opacity: 0.7;
+  }
 }
 
 /* ─── Responsive: mobile (single-column stack, drag to reorder) ─ */
@@ -551,10 +554,6 @@ body::-webkit-scrollbar {
   .gs-wrapper {
     overflow: visible;
     padding: 6px;
-  }
-
-  .grid-stack-item > .ui-resizable-handle {
-    display: none !important;
   }
 
   .snap-card {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -88,7 +88,7 @@
   white-space: nowrap;
   color: var(--primary-vibrant);
   box-shadow: var(--shadow-sm);
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
 }
 
 @utility base-panel {
@@ -98,7 +98,7 @@
   border-radius: var(--radius-panel);
   box-shadow: var(--shadow-sm);
   padding: 1.25rem;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
 }
 
 .base-chip:hover {

--- a/src/styles/zine-editor.css
+++ b/src/styles/zine-editor.css
@@ -8,7 +8,7 @@
   border-radius: 1px;
   position: relative;
   flex-shrink: 0;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
   scroll-margin-top: 1rem;
   padding: 0.2rem;
   overflow: hidden;
@@ -62,7 +62,7 @@
   overflow: hidden;
   cursor: pointer;
   min-height: 7rem;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
   border-radius: var(--radius-button);
   background: var(--surface-muted);
 }

--- a/src/utils/gridStack.js
+++ b/src/utils/gridStack.js
@@ -11,6 +11,7 @@ const DEFAULT_LAYOUT = [
   { id: 'brand', x: 0, y: 0, w: 4, h: 3 },
   { id: 'canvas', x: 0, y: 3, w: 9, h: 10 },
   { id: 'upload', x: 9, y: 3, w: 3, h: 4 },
+  { id: 'settings', x: 9, y: 7, w: 3, h: 10 },
   { id: 'fold-viewer', x: 0, y: 15, w: 6, h: 6 },
   { id: 'fold-booklet', x: 6, y: 15, w: 3, h: 4 },
   { id: 'fold-guide', x: 9, y: 15, w: 3, h: 4 }

--- a/src/utils/gridStack.js
+++ b/src/utils/gridStack.js
@@ -12,7 +12,6 @@ const DEFAULT_LAYOUT = [
   { id: 'canvas', x: 0, y: 3, w: 9, h: 10 },
   { id: 'upload', x: 9, y: 3, w: 3, h: 4 },
   { id: 'settings', x: 9, y: 7, w: 3, h: 10 },
-  { id: 'display', x: 9, y: 11, w: 3, h: 2 },
   { id: 'fold-viewer', x: 0, y: 15, w: 6, h: 6 },
   { id: 'fold-booklet', x: 6, y: 15, w: 3, h: 4 },
   { id: 'fold-guide', x: 9, y: 15, w: 3, h: 4 }
@@ -20,8 +19,6 @@ const DEFAULT_LAYOUT = [
 
 let grid = null;
 let gridEl = null;
-let resizeObserver = null;
-let resizeFrame = null;
 let isRelayouting = false;
 
 function isMobile() {
@@ -66,17 +63,19 @@ function compactLayout() {
   grid.compact('list');
 }
 
-function relayoutPanels() {
+function relayoutPanels({ fitContent = false } = {}) {
   if (!grid) { return; }
   isRelayouting = true;
 
-  grid.getGridItems().forEach((el) => {
-    if (el.querySelector('.grid-stack-item-content')?.firstElementChild) {
-      grid.resizeToContent(el);
-    }
-  });
-  compactLayout();
+  if (fitContent) {
+    grid.getGridItems().forEach((el) => {
+      if (el.querySelector('.grid-stack-item-content')?.firstElementChild) {
+        grid.resizeToContent(el);
+      }
+    });
+  }
 
+  compactLayout();
   isRelayouting = false;
 }
 
@@ -91,8 +90,7 @@ function resetToDefaults() {
   });
   grid.batchUpdate(false);
 
-  if (isMobile()) { compactLayout(); }
-  relayoutPanels();
+  relayoutPanels({ fitContent: true });
 }
 
 function loadLayout() {
@@ -101,13 +99,13 @@ function loadLayout() {
   try {
     const raw = localStorage.getItem(storageKey());
     if (!raw) {
-      relayoutPanels();
+      relayoutPanels({ fitContent: true });
       return;
     }
 
     const items = JSON.parse(raw);
     if (!Array.isArray(items) || !items.length) {
-      relayoutPanels();
+      relayoutPanels({ fitContent: true });
       return;
     }
 
@@ -124,25 +122,6 @@ function loadLayout() {
   } catch {
     resetToDefaults();
   }
-}
-
-function scheduleRelayout() {
-  if (resizeFrame) { cancelAnimationFrame(resizeFrame); }
-  resizeFrame = requestAnimationFrame(() => {
-    relayoutPanels();
-    if (layoutHasOverlaps()) { compactLayout(); }
-    resizeFrame = null;
-  });
-}
-
-function observePanelSizes() {
-  if (resizeObserver) { resizeObserver.disconnect(); }
-
-  resizeObserver = new ResizeObserver(() => scheduleRelayout());
-
-  gridEl?.querySelectorAll('.grid-stack-item .snap-card').forEach((card) => {
-    resizeObserver.observe(card);
-  });
 }
 
 function syncGridMetrics() {
@@ -185,9 +164,8 @@ export function initGridStack() {
   grid.float(!isMobile());
 
   grid.on('change', saveLayout);
-  grid.on('dragstop resizestop', () => scheduleRelayout());
+  grid.on('dragstop resizestop', saveLayout);
 
-  observePanelSizes();
   setInteractionMode();
 
   window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`).addEventListener('change', setInteractionMode);

--- a/src/utils/gridStack.js
+++ b/src/utils/gridStack.js
@@ -11,7 +11,7 @@ const DEFAULT_LAYOUT = [
   { id: 'brand', x: 0, y: 0, w: 4, h: 3 },
   { id: 'canvas', x: 0, y: 3, w: 9, h: 10 },
   { id: 'upload', x: 9, y: 3, w: 3, h: 4 },
-  { id: 'settings', x: 9, y: 7, w: 3, h: 10 },
+  { id: 'settings', x: 9, y: 7, w: 3, h: 8 },
   { id: 'fold-viewer', x: 0, y: 15, w: 6, h: 6 },
   { id: 'fold-booklet', x: 6, y: 15, w: 3, h: 4 },
   { id: 'fold-guide', x: 9, y: 15, w: 3, h: 4 }

--- a/src/utils/gridStack.js
+++ b/src/utils/gridStack.js
@@ -11,7 +11,6 @@ const DEFAULT_LAYOUT = [
   { id: 'brand', x: 0, y: 0, w: 4, h: 3 },
   { id: 'canvas', x: 0, y: 3, w: 9, h: 10 },
   { id: 'upload', x: 9, y: 3, w: 3, h: 4 },
-  { id: 'settings', x: 9, y: 7, w: 3, h: 10 },
   { id: 'fold-viewer', x: 0, y: 15, w: 6, h: 6 },
   { id: 'fold-booklet', x: 6, y: 15, w: 3, h: 4 },
   { id: 'fold-guide', x: 9, y: 15, w: 3, h: 4 }

--- a/src/utils/gridStack.js
+++ b/src/utils/gridStack.js
@@ -63,7 +63,7 @@ function saveLayout() {
 }
 
 function compactLayout() {
-  if (!grid) { return; }
+  if (!grid || !isMobile()) { return; }
   grid.compact('list');
 }
 
@@ -143,7 +143,7 @@ function syncGridMetrics() {
   const mobile = isMobile();
   grid.cellHeight(mobile ? MOBILE_CELL_HEIGHT : CELL_HEIGHT);
   grid.margin(mobile ? 4 : 8);
-  grid.float(false);
+  grid.float(!mobile);
 }
 
 function setInteractionMode() {
@@ -164,7 +164,7 @@ export function initGridStack() {
     column: 12,
     cellHeight: CELL_HEIGHT,
     margin: isMobile() ? 6 : 8,
-    float: false,
+    float: !isMobile(),
     animate: true,
     sizeToContent: true,
     resizable: { handles: 'se', autoHide: false },
@@ -175,7 +175,7 @@ export function initGridStack() {
     }
   }, gridEl);
 
-  grid.float(false);
+  grid.float(!isMobile());
 
   grid.on('change', saveLayout);
   grid.on('dragstop resizestop', () => scheduleRelayout());

--- a/src/utils/gridStack.js
+++ b/src/utils/gridStack.js
@@ -11,7 +11,7 @@ const DEFAULT_LAYOUT = [
   { id: 'brand', x: 0, y: 0, w: 4, h: 3 },
   { id: 'canvas', x: 0, y: 3, w: 9, h: 10 },
   { id: 'upload', x: 9, y: 3, w: 3, h: 4 },
-  { id: 'settings', x: 9, y: 7, w: 3, h: 4 },
+  { id: 'settings', x: 9, y: 7, w: 3, h: 10 },
   { id: 'display', x: 9, y: 11, w: 3, h: 2 },
   { id: 'export', x: 0, y: 13, w: 4, h: 2 },
   { id: 'fold-viewer', x: 0, y: 15, w: 6, h: 6 },

--- a/src/utils/gridStack.js
+++ b/src/utils/gridStack.js
@@ -13,7 +13,6 @@ const DEFAULT_LAYOUT = [
   { id: 'upload', x: 9, y: 3, w: 3, h: 4 },
   { id: 'settings', x: 9, y: 7, w: 3, h: 10 },
   { id: 'display', x: 9, y: 11, w: 3, h: 2 },
-  { id: 'export', x: 0, y: 13, w: 4, h: 2 },
   { id: 'fold-viewer', x: 0, y: 15, w: 6, h: 6 },
   { id: 'fold-booklet', x: 6, y: 15, w: 3, h: 4 },
   { id: 'fold-guide', x: 9, y: 15, w: 3, h: 4 }
@@ -71,7 +70,11 @@ function relayoutPanels() {
   if (!grid) { return; }
   isRelayouting = true;
 
-  grid.getGridItems().forEach((el) => grid.resizeToContent(el));
+  grid.getGridItems().forEach((el) => {
+    if (el.querySelector('.grid-stack-item-content')?.firstElementChild) {
+      grid.resizeToContent(el);
+    }
+  });
   compactLayout();
 
   isRelayouting = false;
@@ -108,8 +111,12 @@ function loadLayout() {
       return;
     }
 
-    grid.load(items);
+    const validIds = new Set(
+      [...gridEl.querySelectorAll('.grid-stack-item')].map((el) => el.getAttribute('gs-id'))
+    );
+    grid.load(items.filter((item) => validIds.has(item.id)));
     relayoutPanels();
+    saveLayout();
 
     if (layoutHasOverlaps()) {
       resetToDefaults();

--- a/src/utils/gridStack.js
+++ b/src/utils/gridStack.js
@@ -112,7 +112,10 @@ function loadLayout() {
     const validIds = new Set(
       [...gridEl.querySelectorAll('.grid-stack-item')].map((el) => el.getAttribute('gs-id'))
     );
-    grid.load(items.filter((item) => validIds.has(item.id)));
+    const savedItems = items.filter((item) => validIds.has(item.id));
+    const savedIds = new Set(savedItems.map((item) => item.id));
+    const missingItems = DEFAULT_LAYOUT.filter(({ id }) => validIds.has(id) && !savedIds.has(id));
+    grid.load([...savedItems, ...missingItems]);
     relayoutPanels();
     saveLayout();
 


### PR DESCRIPTION
### Summary
Consolidates the Export PDF action into the Brand panel, makes the Settings panel freely draggable like other panels, and applies a broad visual/accessibility refresh across the workspace.

### Problem
The Export panel was a separate, disconnected block from Branding, the Settings panel could not be moved as freely as other panels, and the overall UI relied on generic transitions and inline styles that made panels feel inconsistent and hard to maintain.

### Solution
Merged Export PDF into the Brand panel with its own drag handle, removed the standalone Export and Display panels, reworked panel sizing/scrolling behavior, and introduced shared CSS utility classes for icons, transitions, and panel scroll bodies to reduce duplication. GridStack layout logic was also updated to better preserve/merge saved layouts and only compact on mobile.

### Key Changes
- **Brand panel**: added a dedicated drag handle, moved the Export PDF button into the brand panel actions, enlarged logo sizing with explicit width/height attributes for layout stability.
- **Removed standalone panels**: deleted the separate "Display options" and "Export PDF" grid-stack panels/markup; export action now lives in the Brand panel.
- **Settings panel**: renamed to "Sheet setup", made attachable/dockable (`attachable-panel-item`, `settings-panel-item` classes), increased height, added scrollable body via `panel-scroll-body`.
- **Accessibility**: added a skip link to `#workspace-main`, converted `.gs-wrapper` to a `<main>` landmark, added `:focus-visible` outline styling, and respected `prefers-reduced-motion`.
- **CSS cleanup**: replaced numerous `transition: all` declarations with explicit property lists across `components.css`, `layout.css`, `theme.css`, and `zine-editor.css`; extracted inline styles into utility classes (`icon-compact`, `icon-tiny`, `upload-icon`, `slider-icon`, `progress-icon`, `muted-copy`, `is-hidden`, `fold-slider`).
- **Studio visual pass**: added new workspace grid background, "work table" watermark, updated panel shadows/border-radius, hover/drag z-index handling, and print/page cell styling in `index.css`.
- **GridStack (`gridStack.js`)**: removed `display`/`export` from `DEFAULT_LAYOUT`, replaced ResizeObserver-based relayout scheduling with a simpler `relayoutPanels({ fitContent })` API, only compact on mobile, merge saved layout items with default layout for missing/valid ids, and toggle `float` based on mobile state.
- **Layout tweaks**: resizable handles remain visible on tablet/mobile with reduced opacity, panel handles (`snap-card-handle`) now always displayed instead of hidden by default, `grid-stack-item` overflow changed to `visible` with isolation for proper hover/drag stacking.
- Removed unused `landscapeW`/`landscapeH` calculations in `SmartSheetConfig.js`.
- Added `preconnect` links for Google Fonts in `index.html` for faster font loading.


---

<a href="https://builder.io/app/projects/a0a0c9b3e62743a89532/crimson-ship-c9quvlzu"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://a0a0c9b3e62743a89532-crimson-ship-c9quvlzu.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

> [!TIP]
> This PR wasn't reviewed by Quality Agent. [Enable it in Project Settings](https://builder.io/app/projects?openProjectSettings=a0a0c9b3e62743a89532&projectSettingsTab=review&highlight=codeReview) to get AI-powered code review on every PR.



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 528`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a0a0c9b3e62743a89532</projectId>-->
<!--<branchName>crimson-ship-c9quvlzu</branchName>-->